### PR TITLE
Feature/issue 003 update tests for pester v5

### DIFF
--- a/Installer/GitHooksInstaller_HelperFunctions.ps1
+++ b/Installer/GitHooksInstaller_HelperFunctions.ps1
@@ -6,8 +6,8 @@ Helper functions for installing Git hook scripts on a user's computer.
 Author:			Simon Elms
 Requires:		PowerShell 5
                 Pslogg module (see https://github.com/AnotherSadGit/Pslogg_PowerShellLogger)
-Date:			9 Jul 2019
-Version:		1.0.0
+Date:			30 Dec 2023
+Version:		2.0.0
 
 #>
 
@@ -44,18 +44,8 @@ function Install-RequiredModule (
     {
         return
     }
-    
-    # Repository probably has too many modules to enumerate them all to find the name.  So call 
-    # "Find-Module -Repository $RepositoryName -Name $ModuleName" which will raise a 
-    # non-terminating error if the module isn't found.
 
-    # Silently continue on error because the error message isn't user friendly.  We'll display 
-    # our own error message if needed.
-    if ((Find-Module -Repository $RepositoryName -Name $ModuleName `
-        -ErrorAction SilentlyContinue -WarningAction SilentlyContinue).Count -eq 0)
-    {
-        throw "Module '$ModuleName' not found in repository '$RepositoryName'.  Exiting."
-    }
+    $errorHeader = "Unable to install module '$ModuleName'"
 
     try
     {
@@ -70,7 +60,19 @@ function Install-RequiredModule (
     }
     catch 
     {
-        throw "Module repository '$RepositoryName' not found.  Exiting."
+        throw "${errorHeader}: Module repository '$RepositoryName' not found.  Exiting."
+    }
+    
+    # Repository probably has too many modules to enumerate them all to find the name.  So call 
+    # "Find-Module -Repository $RepositoryName -Name $ModuleName" which will raise a 
+    # non-terminating error if the module isn't found.
+
+    # Silently continue on error because the error message isn't user friendly.  We'll display 
+    # our own error message if needed.
+    if ((Find-Module -Repository $RepositoryName -Name $ModuleName `
+        -ErrorAction SilentlyContinue -WarningAction SilentlyContinue).Count -eq 0)
+    {
+        throw "${errorHeader}: Module '$ModuleName' not found in repository '$RepositoryName'.  Exiting."
     }
     
     try
@@ -88,7 +90,7 @@ function Install-RequiredModule (
 
         if ([string]::IsNullOrWhiteSpace($ProxyUrl))
         {
-            throw "Unable to install module '$ModuleName' directly and no proxy server details supplied.  Exiting."
+            throw "${errorHeader}: Unable to install module directly and no proxy server details supplied.  Exiting."
         }
 
         $proxyCredential = Get-Credential -Message 'Please enter credentials for proxy server'
@@ -102,7 +104,7 @@ function Install-RequiredModule (
 
     if (-not (Get-InstalledModule -Name $ModuleName -ErrorAction SilentlyContinue))
     {
-        throw "Unknown error installing module '$ModuleName' from repository '$RepositoryName'.  Exiting."
+        throw "${errorHeader}: Unknown error installing module from repository '$RepositoryName'.  Exiting."
     }
 
     Write-Output "Module '$ModuleName' successfully installed."

--- a/PesterTests/GitHooksInstaller_FileCopyFunctions.Tests.ps1
+++ b/PesterTests/GitHooksInstaller_FileCopyFunctions.Tests.ps1
@@ -5,300 +5,329 @@ Tests of the functions in the GitHooksInstaller_FileCopyFunctions.ps1 file.
 .NOTES
 Author:			Simon Elms
 Requires:		PowerShell 5
-                AssertExceptionThrown module (see https://github.com/AnotherSadGit/PesterAssertExceptionThrown)
-Date:			4 Jul 2019
-Version:		1.0.0
+                Pester v5
+Date:			30 Dec 2023
+Version:		2.0.0
 #>
 
-# NOTE: #Requires is not a comment, it's a requires directive.
-#Requires -Modules AssertExceptionThrown
+BeforeAll {
+    # NOTE: The script under test has to be dot sourced in a BeforeAll block, not a 
+    # BeforeDiscovery block.  If placed in a BeforeDiscovery block the tests will fail.
+    # (this is in contrast to importing a module under test, which has to be done in the 
+    # BeforeDiscovery block)
 
-# Can't dot source directly using a simple relative path as relative paths are relative to the 
-# current working directory, not the directory this test file is in.  The current working 
-# directory could be anything.  So Use $PSScriptRoot to get the directory this file is in, and 
-# use a path relative to that.
-. (Join-Path $PSScriptRoot '..\Installer\GitHooksInstaller_FileCopyFunctions.ps1' -Resolve)
+    # Use $PSScriptRoot so this script will always dot source the script file in the Installer 
+    # folder adjacent to the folder containing this script, regardless of the location that 
+    # Pester is invoked from:
+    #                                     {parent folder}
+    #                                             |
+    #                   -----------------------------------------------------
+    #                   |                                                   |
+    #     {folder containing this script}                                Installer folder
+    #                   |                                                   |
+    #                   |                                                   |
+    #               This script -----------> dot sources ------------->  script file under test
+    . (Join-Path $PSScriptRoot '..\Installer\GitHooksInstaller_FileCopyFunctions.ps1' -Resolve)
 
-#region Common helper functions *******************************************************************
+    #region Common helper functions *******************************************************************
 
-function GetArrayDisplayText ([array]$Array)
-{
-    if ($Array -eq $Null)
+    function GetArrayDisplayText ([array]$Array)
     {
-        return '[NULL]'
+        if ($Array -eq $Null)
+        {
+            return '[NULL]'
+        }
+
+        if ($Array.Count -eq 0)
+        {
+            return '[EMPTY]'
+        }
+
+        return $Array -join ', '
     }
 
-    if ($Array.Count -eq 0)
+    function AssertArrayMatch ([array]$ExpectedArray, [array]$ActualArray)
     {
-        return '[EMPTY]'
-    }
+        $expectedArrayDisplayText = GetArrayDisplayText $ExpectedArray
+        $actualArrayDisplayText = GetArrayDisplayText $ActualArray
 
-    return $Array -join ', '
-}
+        if ($ExpectedArray -eq $Null)
+        {        
+            if ($ActualArray -eq $Null)
+            {
+                return
+            }
 
-function AssertArrayMatch ([array]$ExpectedArray, [array]$ActualArray)
-{
-    $expectedArrayDisplayText = GetArrayDisplayText $ExpectedArray
-    $actualArrayDisplayText = GetArrayDisplayText $ActualArray
+            throw "Expected array to be [NULL].  Actual value: $actualArrayDisplayText"
+        }
 
-    if ($ExpectedArray -eq $Null)
-    {        
         if ($ActualArray -eq $Null)
+        {
+            throw "Expected array to be $expectedArrayDisplayText.  Was actually [NULL]."
+        }
+
+        $errorMessage = "Expected array to be $expectedArrayDisplayText.  Was actually $actualArrayDisplayText."
+
+        if ($ExpectedArray.Count -ne $ActualArray.Count)
+        {
+            throw $errorMessage
+        }
+
+        # Arrays must each have the same number of elements.
+
+        if ($ExpectedArray.Count -eq 0)
         {
             return
         }
 
-        throw "Expected array to be [NULL].  Actual value: $actualArrayDisplayText"
-    }
-
-    if ($ActualArray -eq $Null)
-    {
-        throw "Expected array to be $expectedArrayDisplayText.  Was actually [NULL]."
-    }
-
-    $errorMessage = "Expected array to be $expectedArrayDisplayText.  Was actually $actualArrayDisplayText."
-
-    if ($ExpectedArray.Count -ne $ActualArray.Count)
-    {
-        throw $errorMessage
-    }
-
-    # Arrays must each have the same number of elements.
-
-    if ($ExpectedArray.Count -eq 0)
-    {
-        return
-    }
-
-    for($i = 0; $i -lt $ExpectedArray.Count; $i++)
-    {
-        if ($ExpectedArray[$i] -ne $ActualArray[$i])
+        for ($i = 0; $i -lt $ExpectedArray.Count; $i++)
         {
-            throw $errorMessage
+            if ($ExpectedArray[$i] -ne $ActualArray[$i])
+            {
+                throw $errorMessage
+            }
         }
     }
-}
 
-#endregion
+    #endregion
 
-#region Version number helper functions ***********************************************************
+    #region Version number helper functions ***********************************************************
 
-function GetReferenceVersionArray
-{
-    return @(2,0,0,0)
-}
+    function GetReferenceVersionArray
+    {
+        return @(2, 0, 0, 0)
+    }
 
-function GetOlderVersionArray([array]$ReferenceVersion)
-{
-    $newArray = $ReferenceVersion.Clone()
-    $newArray[0]--
-    return $newArray
-}
+    function GetOlderVersionArray([array]$ReferenceVersion)
+    {
+        $newArray = $ReferenceVersion.Clone()
+        $newArray[0]--
+        return $newArray
+    }
 
-function GetNewerVersionArray([array]$ReferenceVersion)
-{
-    $newArray = $ReferenceVersion.Clone()
-    $newArray[0]++
-    return $newArray
-}
+    function GetNewerVersionArray([array]$ReferenceVersion)
+    {
+        $newArray = $ReferenceVersion.Clone()
+        $newArray[0]++
+        return $newArray
+    }
 
-function GetFileNotExistsVersionArray
-{
-    return @(0,0,0,0)
-}
+    function GetFileNotExistsVersionArray
+    {
+        return @(0, 0, 0, 0)
+    }
 
-function GetFileWithoutVersionNumberArray
-{
-    return @(99999,0,0,0)
-}
+    function GetFileWithoutVersionNumberArray
+    {
+        return @(99999, 0, 0, 0)
+    }
 
-function GetFileVersions (
-    [Parameter(Mandatory=$True, 
-                ParameterSetName="Source")]
-    [Parameter(Mandatory=$True, 
-                ParameterSetName="Source All")]
-    [switch]$IsSource,
+    function GetFileVersions (
+        [Parameter(Mandatory = $True, 
+            ParameterSetName = "Source")]
+        [Parameter(Mandatory = $True, 
+            ParameterSetName = "Source All")]
+        [switch]$IsSource,
     
-    [Parameter(Mandatory=$True, 
-                ParameterSetName="Target")]
-    [Parameter(Mandatory=$True, 
-                ParameterSetName="Target All")]
-    [switch]$IsTarget,
+        [Parameter(Mandatory = $True, 
+            ParameterSetName = "Target")]
+        [Parameter(Mandatory = $True, 
+            ParameterSetName = "Target All")]
+        [switch]$IsTarget,
     
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Source")]
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Target")]
-    [switch]$IncludeTargerOlder,
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Source")]
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Target")]
+        [switch]$IncludeTargerOlder,
     
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Source")]
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Target")]
-    [switch]$IncludeVersionsSame,
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Source")]
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Target")]
+        [switch]$IncludeVersionsSame,
     
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Source")]
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Target")]
-    [switch]$IncludeTargerNewer,
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Source")]
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Target")]
+        [switch]$IncludeTargerNewer,
 
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Source")]
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Target")]
-    [switch]$IncludeTargetNotExist,
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Source")]
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Target")]
+        [switch]$IncludeTargetNotExist,
 
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Source")]
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Target")]
-    [switch]$IncludeTargetNoVersion,
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Source")]
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Target")]
+        [switch]$IncludeTargetNoVersion,
 
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Source All")]
-    [Parameter(Mandatory=$False, 
-                ParameterSetName="Target All")]
-    [switch]$IncludeAll
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Source All")]
+        [Parameter(Mandatory = $False, 
+            ParameterSetName = "Target All")]
+        [switch]$IncludeAll
     )
-{
-    $sourceVersion = GetReferenceVersionArray
-    $targetOlderVersion = GetOlderVersionArray $sourceVersion
-    $targetNewerVersion = GetNewerVersionArray $sourceVersion
-    $targetNotExistsVersion = GetFileNotExistsVersionArray
-    $targetNoVersion = GetFileWithoutVersionNumberArray
+    {
+        $sourceVersion = GetReferenceVersionArray
+        $targetOlderVersion = GetOlderVersionArray $sourceVersion
+        $targetNewerVersion = GetNewerVersionArray $sourceVersion
+        $targetNotExistsVersion = GetFileNotExistsVersionArray
+        $targetNoVersion = GetFileWithoutVersionNumberArray
 
-    $targetOlder_Source = @{
-                                '.\Test_TargetOlder.txt' = $sourceVersion
-                                '.\SubDir\Sub_TargetOlder.txt' = $sourceVersion
-                            }
-    $targetOlder_Target = @{
-                                '.\Test_TargetOlder.txt' = $targetOlderVersion
-                                '.\SubDir\Sub_TargetOlder.txt' = $targetOlderVersion
-                            }
+        $targetOlder_Source = @{
+            '.\Test_TargetOlder.txt'       = $sourceVersion
+            '.\SubDir\Sub_TargetOlder.txt' = $sourceVersion
+        }
+        $targetOlder_Target = @{
+            '.\Test_TargetOlder.txt'       = $targetOlderVersion
+            '.\SubDir\Sub_TargetOlder.txt' = $targetOlderVersion
+        }
                     
-    $versionsSame = @{
-                        '.\Test_SourceSameVersion.txt' = $sourceVersion
-                        '.\SubDir\Sub_SourceSameVersion.txt' = $sourceVersion
-                    } 
+        $versionsSame = @{
+            '.\Test_SourceSameVersion.txt'       = $sourceVersion
+            '.\SubDir\Sub_SourceSameVersion.txt' = $sourceVersion
+        } 
 
-    $targetNewer_Source = @{
-                                '.\Test_TargetNewer.txt' = $sourceVersion
-                                '.\SubDir\Sub_TargetNewer.txt' = $sourceVersion
-                            } 
-    $targetNewer_Target = @{
-                                '.\Test_TargetNewer.txt' = $targetNewerVersion
-                                '.\SubDir\Sub_TargetNewer.txt' = $targetNewerVersion
-                            } 
+        $targetNewer_Source = @{
+            '.\Test_TargetNewer.txt'       = $sourceVersion
+            '.\SubDir\Sub_TargetNewer.txt' = $sourceVersion
+        } 
+        $targetNewer_Target = @{
+            '.\Test_TargetNewer.txt'       = $targetNewerVersion
+            '.\SubDir\Sub_TargetNewer.txt' = $targetNewerVersion
+        } 
 
-    $targetNotExists_Source = @{
-                                    '.\Test_TargetNotExists.txt' = $sourceVersion
-                                    '.\SubDir\Sub_TargetNotExists.txt' = $sourceVersion
-                                }
-    $targetNotExists_Target = @{
-                                    '.\Test_TargetNotExists.txt' = $targetNotExistsVersion
-                                    '.\SubDir\Sub_TargetNotExists.txt' = $targetNotExistsVersion
-                                }
+        $targetNotExists_Source = @{
+            '.\Test_TargetNotExists.txt'       = $sourceVersion
+            '.\SubDir\Sub_TargetNotExists.txt' = $sourceVersion
+        }
+        $targetNotExists_Target = @{
+            '.\Test_TargetNotExists.txt'       = $targetNotExistsVersion
+            '.\SubDir\Sub_TargetNotExists.txt' = $targetNotExistsVersion
+        }
                                 
-    $targetNoVersion_Source = @{
-                                    '.\Test_TargetNoVersion.txt' = $sourceVersion
-                                    '.\SubDir\Sub_TargetNoVersion.txt' = $sourceVersion
-                                }
-    $targetNoVersion_Target = @{
-                                    '.\Test_TargetNoVersion.txt' = $targetNoVersion
-                                    '.\SubDir\Sub_TargetNoVersion.txt' = $targetNoVersion
-                                }
+        $targetNoVersion_Source = @{
+            '.\Test_TargetNoVersion.txt'       = $sourceVersion
+            '.\SubDir\Sub_TargetNoVersion.txt' = $sourceVersion
+        }
+        $targetNoVersion_Target = @{
+            '.\Test_TargetNoVersion.txt'       = $targetNoVersion
+            '.\SubDir\Sub_TargetNoVersion.txt' = $targetNoVersion
+        }
 
-    $output = @{}
+        $output = @{}
 
-    if ($IncludeAll)
-    {
-        $IncludeTargerNewer = $True
-        $IncludeVersionsSame = $True
-        $IncludeTargerOlder = $True
-        $IncludeTargetNotExist = $True
-        $IncludeTargetNoVersion = $True
+        if ($IncludeAll)
+        {
+            $IncludeTargerNewer = $True
+            $IncludeVersionsSame = $True
+            $IncludeTargerOlder = $True
+            $IncludeTargetNotExist = $True
+            $IncludeTargetNoVersion = $True
+        }
+
+        if ($IsSource)
+        {
+            if ($IncludeTargerOlder)
+            {
+                $output = $output + $targetOlder_Source
+            }
+            if ($IncludeVersionsSame)
+            {
+                $output = $output + $versionsSame
+            }
+            if ($IncludeTargerNewer)
+            {
+                $output = $output + $targetNewer_Source
+            }
+            if ($IncludeTargetNotExist)
+            {
+                $output = $output + $targetNotExists_Source
+            }
+            if ($IncludeTargetNoVersion)
+            {
+                $output = $output + $targetNoVersion_Source
+            }
+        }
+        else
+        {
+            if ($IncludeTargerOlder)
+            {
+                $output = $output + $targetOlder_Target
+            }
+            if ($IncludeVersionsSame)
+            {
+                $output = $output + $versionsSame
+            }
+            if ($IncludeTargerNewer)
+            {
+                $output = $output + $targetNewer_Target
+            }
+            if ($IncludeTargetNotExist)
+            {
+                $output = $output + $targetNotExists_Target
+            }
+            if ($IncludeTargetNoVersion)
+            {
+                $output = $output + $targetNoVersion_Target
+            }
+        }
+
+        return $output
     }
 
-    if ($IsSource)
-    {
-        if ($IncludeTargerOlder)
-        {
-            $output = $output + $targetOlder_Source
-        }
-        if ($IncludeVersionsSame)
-        {
-            $output = $output + $versionsSame
-        }
-        if ($IncludeTargerNewer)
-        {
-            $output = $output + $targetNewer_Source
-        }
-        if ($IncludeTargetNotExist)
-        {
-            $output = $output + $targetNotExists_Source
-        }
-        if ($IncludeTargetNoVersion)
-        {
-            $output = $output + $targetNoVersion_Source
-        }
-    }
-    else
-    {
-        if ($IncludeTargerOlder)
-        {
-            $output = $output + $targetOlder_Target
-        }
-        if ($IncludeVersionsSame)
-        {
-            $output = $output + $versionsSame
-        }
-        if ($IncludeTargerNewer)
-        {
-            $output = $output + $targetNewer_Target
-        }
-        if ($IncludeTargetNotExist)
-        {
-            $output = $output + $targetNotExists_Target
-        }
-        if ($IncludeTargetNoVersion)
-        {
-            $output = $output + $targetNoVersion_Target
-        }
-    }
+    #endregion
 
-    return $output
+    function GetTargetFileNames
+    {
+        return @(
+            'applypatch-msg'                      
+            'commit-msg'                          
+            'post-update'                         
+            'pre-applypatch'                      
+            'pre-commit'                          
+            'pre-push'                            
+            'pre-rebase'                          
+            'prepare-commit-msg'                  
+            'update'    
+        )
+    }
 }
-
-#endregion
 
 #region Copy all files under source directory to target directory *********************************
 
-function GetFilesToUpdate
-{    
-    return @(
-                '.\Test_TargetOlder.txt'
-                '.\Test_TargetNotExists.txt'
-                '.\SubDir\Sub_TargetOlder.txt'
-                '.\SubDir\Sub_TargetNotExists.txt'
-            )
-}
-
 Describe 'Get-SourceFileToCopy' {
 
-    # Mock the commands outside the It blocks as a reminder the mocked commands persist into 
-    # subsequent It blocks.
+    BeforeAll {
 
-    Mock Write-LogMessage
+        Mock Write-LogMessage
 
-    $sourceDirectoryPath = 'TestDrive:\SourceDir'
-    $targetDirectoryPath = 'TestDrive:\TargetDir'
+        $sourceDirectoryPath = 'TestDrive:\SourceDir'
+        $targetDirectoryPath = 'TestDrive:\TargetDir'
 
-    Mock Get-DirectoryFileRelativePath { return @() }
+        Mock Get-DirectoryFileRelativePath { return @() }
+
+        function Mock-GetDirectoryScriptVersion ()
+        {
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeTargerNewer } `
+                -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
+            
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeTargerNewer } `
+                -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
+
+            Mock Test-Path { return $True }
+        }
+    }
 
     Context 'no versioned files found in source directory' {
         
-        Mock Get-DirectoryScriptVersion { return @() }
+        BeforeAll {
+            Mock Get-DirectoryScriptVersion { return @() }
+        }
 
         It 'returns empty array' {
             $result = Get-SourceFileToCopy -SourceDirectory $sourceDirectoryPath `
@@ -313,7 +342,10 @@ Describe 'Get-SourceFileToCopy' {
     }
 
     Context 'target directory does not exist' {
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeAll }
+
+        BeforeAll {
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeAll }
+        }
 
         It 'returns all source file relative paths' {
             $result = Get-SourceFileToCopy -SourceDirectory $sourceDirectoryPath `
@@ -329,13 +361,16 @@ Describe 'Get-SourceFileToCopy' {
     }
 
     Context 'all target file versions are newer than source file versions' {
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeTargerNewer } `
-            -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
-            
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeTargerNewer } `
-            -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
 
-        Mock Test-Path { return $True }
+        BeforeAll {
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeTargerNewer } `
+                -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
+            
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeTargerNewer } `
+                -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
+
+            Mock Test-Path { return $True }
+        }
 
         It 'returns Null' {
             $result = Get-SourceFileToCopy -SourceDirectory $sourceDirectoryPath `
@@ -346,13 +381,16 @@ Describe 'Get-SourceFileToCopy' {
     }
 
     Context 'all source and target files have same versions' {
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeVersionsSame } `
-            -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
-            
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeVersionsSame } `
-            -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
 
-        Mock Test-Path { return $True }
+        BeforeAll {
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeVersionsSame } `
+                -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
+            
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeVersionsSame } `
+                -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
+
+            Mock Test-Path { return $True }
+        }
 
         It 'returns Null' {
             $result = Get-SourceFileToCopy -SourceDirectory $sourceDirectoryPath `
@@ -363,13 +401,16 @@ Describe 'Get-SourceFileToCopy' {
     }
 
     Context 'all target file versions are older than source file versions' {
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeTargerOlder } `
-            -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
-            
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeTargerOlder } `
-            -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
 
-        Mock Test-Path { return $True }
+        BeforeAll {
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeTargerOlder } `
+                -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
+            
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeTargerOlder } `
+                -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
+
+            Mock Test-Path { return $True }
+        }
 
         It 'returns all source file relative paths' {
             $result = Get-SourceFileToCopy -SourceDirectory $sourceDirectoryPath `
@@ -385,13 +426,16 @@ Describe 'Get-SourceFileToCopy' {
     }
 
     Context 'target files do not exist' {
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeTargetNotExist } `
-            -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
-            
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeTargetNotExist } `
-            -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
 
-        Mock Test-Path { return $True }
+        BeforeAll {
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeTargetNotExist } `
+                -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
+            
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeTargetNotExist } `
+                -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
+
+            Mock Test-Path { return $True }
+        }
 
         It 'returns all source file relative paths' {
             $result = Get-SourceFileToCopy -SourceDirectory $sourceDirectoryPath `
@@ -407,13 +451,16 @@ Describe 'Get-SourceFileToCopy' {
     }
 
     Context 'target files have no version numbers' {
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeTargetNoVersion } `
-            -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
-            
-        Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeTargetNoVersion } `
-            -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
 
-        Mock Test-Path { return $True }
+        BeforeAll {
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsSource -IncludeTargetNoVersion } `
+                -ParameterFilter { $DirectoryPath -eq $sourceDirectoryPath }
+            
+            Mock Get-DirectoryScriptVersion { return GetFileVersions -IsTarget -IncludeTargetNoVersion } `
+                -ParameterFilter { $DirectoryPath -eq $targetDirectoryPath }
+
+            Mock Test-Path { return $True }
+        }
 
         It 'returns Null' {
             $result = Get-SourceFileToCopy -SourceDirectory $sourceDirectoryPath `
@@ -426,22 +473,35 @@ Describe 'Get-SourceFileToCopy' {
 
 Describe 'Set-TargetFileFromSourceDirectory' {
 
-    # Mock the commands outside the It blocks as a reminder the mocked commands persist into 
-    # subsequent It blocks.
+    BeforeAll {
 
-    Mock Write-LogMessage
+        $sourceFileNamesToCopy = (GetFileVersions -IsSource -IncludeTargerOlder -IncludeTargetNotExist).Keys
+        Mock Get-SourceFileToCopy { return $sourceFileNamesToCopy }
 
-    $sourceDirectoryPath = 'TestDrive:\SourceDir'
-    $targetDirectoryPath = 'TestDrive:\TargetDir'
+        Mock Test-Path { return $False }
+
+        Mock Set-File { return $False }
+
+        Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly = $False } }
+
+        Mock Copy-Item
+
+        Mock Write-LogMessage
+
+        $sourceDirectoryPath = 'TestDrive:\SourceDir'
+        $targetDirectoryPath = 'TestDrive:\TargetDir'
+    }
 
     Context 'no files need updating' {
         
-        Mock Get-SourceFileToCopy { return $Null }
-        Mock Test-Path { return $True }
-        Mock Set-File { return $True }
-        Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly=$False } }
-        Mock Copy-Item
+        BeforeAll {
+            Mock Get-SourceFileToCopy { return $Null }
 
+            Mock Test-Path { return $True }
+    
+            Mock Set-File { return $True }
+        }
+        
         It 'does not attempt to update files in target directory' {
             Set-TargetFileFromSourceDirectory `
                 -SourceDirectory $sourceDirectoryPath -TargetDirectory $targetDirectoryPath
@@ -453,19 +513,18 @@ Describe 'Set-TargetFileFromSourceDirectory' {
 
     Context 'source file does not exist' {
         
-        $sourceFileNamesToCopy = (GetFileVersions -IsSource -IncludeTargerOlder -IncludeTargetNotExist).Keys
-        Mock Get-SourceFileToCopy { return $sourceFileNamesToCopy }
-        Mock Test-Path { return $False }
-        Mock Set-File { return $True }
-        Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly=$False } }
-        Mock Copy-Item
+        BeforeAll {
+            Mock Set-File { return $true }
+        }
 
         It 'checks existence of source file' {
             
-            try {
+            try
+            {
                 Set-TargetFileFromSourceDirectory `
                     -SourceDirectory $sourceDirectoryPath -TargetDirectory $targetDirectoryPath
-            } catch {}
+            }
+            catch {}
 
             Assert-MockCalled Test-Path -Scope It -Times 1
             Assert-MockCalled Set-File -Scope It -Times 0 -Exactly
@@ -473,10 +532,12 @@ Describe 'Set-TargetFileFromSourceDirectory' {
 
         It 'does not attempt to update target file' {
 
-            try {
+            try
+            {
                 Set-TargetFileFromSourceDirectory `
                     -SourceDirectory $sourceDirectoryPath -TargetDirectory $targetDirectoryPath
-            } catch {}
+            }
+            catch {}
 
             Assert-MockCalled Set-File -Scope It -Times 0 -Exactly
         }
@@ -484,19 +545,16 @@ Describe 'Set-TargetFileFromSourceDirectory' {
         It 'throws exception' {
 
             { Set-TargetFileFromSourceDirectory `
-                -SourceDirectory $sourceDirectoryPath `
-                -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -WithMessage 'File not found'
+                    -SourceDirectory $sourceDirectoryPath `
+                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -WithMessage 'File not found'
         }
     }
 
     Context 'target file creation fails' {
         
-        $sourceFileNamesToCopy = (GetFileVersions -IsSource -IncludeTargerOlder -IncludeTargetNotExist).Keys
-        Mock Get-SourceFileToCopy { return $sourceFileNamesToCopy }
-        Mock Test-Path { return $True }
-        Mock Set-File { return $False }
-        Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly=$False } }
-        Mock Copy-Item
+        BeforeAll {
+            Mock Test-Path { return $True }
+        }
 
         It 'does not attempt to update target file' {
 
@@ -509,19 +567,20 @@ Describe 'Set-TargetFileFromSourceDirectory' {
         It 'does not throw an exception' {
 
             { Set-TargetFileFromSourceDirectory `
-                -SourceDirectory $sourceDirectoryPath `
-                -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -SourceDirectory $sourceDirectoryPath `
+                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
         }
     }
 
     Context 'target file is read-only' {
         
-        $sourceFileNamesToCopy = (GetFileVersions -IsSource -IncludeTargerOlder -IncludeTargetNotExist).Keys
-        Mock Get-SourceFileToCopy { return $sourceFileNamesToCopy }
-        Mock Test-Path { return $True }
-        Mock Set-File { return $True }
-        Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly=$True } }
-        Mock Copy-Item
+        BeforeAll {
+            Mock Test-Path { return $True }
+    
+            Mock Set-File { return $True }
+
+            Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly = $True } }
+        }
 
         It 'does not attempt to update target file' {
 
@@ -534,19 +593,17 @@ Describe 'Set-TargetFileFromSourceDirectory' {
         It 'does not throw an exception' {
 
             { Set-TargetFileFromSourceDirectory `
-                -SourceDirectory $sourceDirectoryPath `
-                -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -SourceDirectory $sourceDirectoryPath `
+                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
         }
     }
 
     Context 'target file is writable' {
         
-        $sourceFileNamesToCopy = (GetFileVersions -IsSource -IncludeTargerOlder -IncludeTargetNotExist).Keys
-        Mock Get-SourceFileToCopy { return $sourceFileNamesToCopy }
-        Mock Test-Path { return $True }
-        Mock Set-File { return $True }
-        Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly=$False } }
-        Mock Copy-Item 
+        BeforeAll {
+            Mock Test-Path { return $True }
+            Mock Set-File { return $True }
+        }
 
         It 'updates each target file' {
 
@@ -559,28 +616,28 @@ Describe 'Set-TargetFileFromSourceDirectory' {
 
     Context 'check target file names' {
         
-        $sourceFileNamesToCopy = (GetFileVersions -IsSource -IncludeTargerOlder -IncludeTargetNotExist).Keys
-        Mock Get-SourceFileToCopy { return $sourceFileNamesToCopy }
-        Mock Test-Path { return $True }
-        Mock Set-File { return $True }
-        Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly=$False } }
-        Mock Copy-Item {
-            $sourceFileFullPath = $Path
-            $targetFileFullPath = $Destination
-            $sourceFile = Split-Path -Path $sourceFileFullPath -Leaf
-            $targetFile = Split-Path -Path $targetFileFullPath -Leaf
-
-            if ($targetFile -ne $sourceFile)
-            {
-                throw "Expected target file name to be the same as the source file name: '$sourceFile'.  Actual target file name is '$targetFile'."
-            }
-        }        
+        BeforeAll {
+            Mock Test-Path { return $True }
+            Mock Set-File { return $True }
+            
+            Mock Copy-Item {
+                $sourceFileFullPath = $Path
+                $targetFileFullPath = $Destination
+                $sourceFile = Split-Path -Path $sourceFileFullPath -Leaf
+                $targetFile = Split-Path -Path $targetFileFullPath -Leaf
+    
+                if ($targetFile -ne $sourceFile)
+                {
+                    throw "Expected target file name to be the same as the source file name: '$sourceFile'.  Actual target file name is '$targetFile'."
+                }
+            }        
+        }
 
         It 'copies each source file to a target file of the same name' {
 
             { Set-TargetFileFromSourceDirectory `
-                -SourceDirectory $sourceDirectoryPath `
-                -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -SourceDirectory $sourceDirectoryPath `
+                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
         }
     }
 }
@@ -589,48 +646,36 @@ Describe 'Set-TargetFileFromSourceDirectory' {
 
 #region Copy single source file multiple times to target directory with different names ***********
 
-function GetTargetFileNames
-{
-    return @(
-                'applypatch-msg'                      
-                'commit-msg'                          
-                'post-update'                         
-                'pre-applypatch'                      
-                'pre-commit'                          
-                'pre-push'                            
-                'pre-rebase'                          
-                'prepare-commit-msg'                  
-                'update'    
-            )
-}
-
 Describe 'Get-TargetFileToUpdate' {
 
-    # Mock the commands outside the It blocks as a reminder the mocked commands persist into 
-    # subsequent It blocks.
+    BeforeAll {
+        Mock Write-LogMessage
 
-    Mock Write-LogMessage
-
-    $sourceFilePath = 'TestDrive:\SourceDir\Source.txt'
-    $targetFileNameList = GetTargetFileNames
-    $targetDirectoryPath = 'TestDrive:\TargetDir'
+        $sourceFilePath = 'TestDrive:\SourceDir\Source.txt'
+        $targetFileNameList = GetTargetFileNames
+        $targetDirectoryPath = 'TestDrive:\TargetDir'
+    }
 
     Context 'source file has no version number' {
         
-        Mock Get-ScriptFileVersion { return GetFileWithoutVersionNumberArray }
+        BeforeAll {
+            Mock Get-ScriptFileVersion { return GetFileWithoutVersionNumberArray }
+        }
 
         It 'throws exception' {
             
             { Get-TargetFileToUpdate -SourceFilePath $sourceFilePath `
-                -TargetFileNameList $targetFileNameList -TargetDirectory $targetDirectoryPath } | 
-                    Assert-ExceptionThrown -WithMessage 'has no version number'
+                    -TargetFileNameList $targetFileNameList -TargetDirectory $targetDirectoryPath } | 
+            Assert-ExceptionThrown -WithMessage 'has no version number'
         }
     }
 
     Context 'target directory does not exist' {
         
-        Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
-        Mock Test-Path { return $False }
+        BeforeAll {
+            Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
+            Mock Test-Path { return $False }
+        }
 
         It 'returns target file list unchanged' {
             
@@ -644,10 +689,12 @@ Describe 'Get-TargetFileToUpdate' {
 
     Context 'all target file versions are newer than source file version' {
         
-        Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
-        Mock Test-Path { return $True }
-        $targetFileVersions = GetFileVersions -IsTarget -IncludeTargerNewer
-        Mock Get-DirectoryScriptVersion { return $targetFileVersions }
+        BeforeAll {
+            Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
+            Mock Test-Path { return $True }
+            $targetFileVersions = GetFileVersions -IsTarget -IncludeTargerNewer
+            Mock Get-DirectoryScriptVersion { return $targetFileVersions }
+        }
 
         It 'returns Null' {
             
@@ -660,10 +707,12 @@ Describe 'Get-TargetFileToUpdate' {
 
     Context 'all target file versions are equal to source file version' {
         
-        Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
-        Mock Test-Path { return $True }
-        $targetFileVersions = GetFileVersions -IsTarget -IncludeVersionsSame
-        Mock Get-DirectoryScriptVersion { return $targetFileVersions }
+        BeforeAll {
+            Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
+            Mock Test-Path { return $True }
+            $targetFileVersions = GetFileVersions -IsTarget -IncludeVersionsSame
+            Mock Get-DirectoryScriptVersion { return $targetFileVersions }
+        }
 
         It 'returns Null' {
             
@@ -676,10 +725,12 @@ Describe 'Get-TargetFileToUpdate' {
 
     Context 'all target file versions are older than source file version' {
         
-        Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
-        Mock Test-Path { return $True }
-        $targetFileVersions = GetFileVersions -IsTarget -IncludeTargerOlder
-        Mock Get-DirectoryScriptVersion { return $targetFileVersions }
+        BeforeAll {
+            Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
+            Mock Test-Path { return $True }
+            $targetFileVersions = GetFileVersions -IsTarget -IncludeTargerOlder
+            Mock Get-DirectoryScriptVersion { return $targetFileVersions }
+        }
 
         It 'returns all target file names' {
             
@@ -695,10 +746,12 @@ Describe 'Get-TargetFileToUpdate' {
 
     Context 'target files do not exist' {
         
-        Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
-        Mock Test-Path { return $True }
-        $targetFileVersions = GetFileVersions -IsTarget -IncludeTargetNotExist
-        Mock Get-DirectoryScriptVersion { return $targetFileVersions }
+        BeforeAll {
+            Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
+            Mock Test-Path { return $True }
+            $targetFileVersions = GetFileVersions -IsTarget -IncludeTargetNotExist
+            Mock Get-DirectoryScriptVersion { return $targetFileVersions }
+        }
 
         It 'returns all target file names' {
             
@@ -714,10 +767,12 @@ Describe 'Get-TargetFileToUpdate' {
 
     Context 'target files have no version numbers' {
         
-        Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
-        Mock Test-Path { return $True }
-        $targetFileVersions = GetFileVersions -IsTarget -IncludeTargetNoVersion
-        Mock Get-DirectoryScriptVersion { return $targetFileVersions }
+        BeforeAll {
+            Mock Get-ScriptFileVersion { return GetReferenceVersionArray }
+            Mock Test-Path { return $True }
+            $targetFileVersions = GetFileVersions -IsTarget -IncludeTargetNoVersion
+            Mock Get-DirectoryScriptVersion { return $targetFileVersions }
+        }
 
         It 'returns Null' {
             
@@ -731,37 +786,43 @@ Describe 'Get-TargetFileToUpdate' {
 
 Describe 'Set-TargetFileFromSourceFile' {
 
-    # Mock the commands outside the It blocks as a reminder the mocked commands persist into 
-    # subsequent It blocks.
+    BeforeAll {
+        Mock Write-LogMessage
 
-    Mock Write-LogMessage
-
-    $sourceFilePath = 'TestDrive:\SourceDir\Source.txt'
-    $targetFileNameList = GetTargetFileNames
-    $targetDirectoryPath = 'TestDrive:\TargetDir'
+        $sourceFilePath = 'TestDrive:\SourceDir\Source.txt'
+        $targetFileNameList = GetTargetFileNames
+        $targetDirectoryPath = 'TestDrive:\TargetDir'
+    }
 
     Context 'source file does not exist' {
-        Mock Test-Path { return $False }
-        Mock Get-TargetFileToUpdate
+
+        BeforeAll {
+            Mock Test-Path { return $False }
+            Mock Get-TargetFileToUpdate
+        }
 
         It 'checks existence of source file' {
             
-            try {
+            try
+            {
                 Set-TargetFileFromSourceFile `
                     -SourceFilePath $sourceFilePath `
                     -TargetFileNameList $targetFileNameList -TargetDirectory $targetDirectoryPath
-            } catch {}
+            }
+            catch {}
 
             Assert-MockCalled Test-Path -Scope It -Times 1
         }
 
         It 'does not attempt to update target files' {
 
-            try {
+            try
+            {
                 Set-TargetFileFromSourceFile `
                     -SourceFilePath $sourceFilePath `
                     -TargetFileNameList $targetFileNameList -TargetDirectory $targetDirectoryPath
-            } catch {}
+            }
+            catch {}
 
             Assert-MockCalled Get-TargetFileToUpdate -Scope It -Times 0 -Exactly
         }
@@ -769,18 +830,20 @@ Describe 'Set-TargetFileFromSourceFile' {
         It 'throws exception' {
 
             { Set-TargetFileFromSourceFile `
-                -SourceFilePath $sourceFilePath `
-                -TargetFileNameList $targetFileNameList `
-                -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -WithMessage 'not found'
+                    -SourceFilePath $sourceFilePath `
+                    -TargetFileNameList $targetFileNameList `
+                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -WithMessage 'not found'
         }
     }
 
     Context 'creating target files' {
         
-        $targetFileNames = GetTargetFileNames
-        Mock Test-Path { return $True }
-        Mock Get-TargetFileToUpdate { return $targetFileNames }
-        Mock Set-File
+        BeforeAll {
+            $targetFileNames = GetTargetFileNames
+            Mock Test-Path { return $True }
+            Mock Get-TargetFileToUpdate { return $targetFileNames }
+            Mock Set-File
+        }
 
         It "creates target files when they don't exist" {
 
@@ -794,11 +857,13 @@ Describe 'Set-TargetFileFromSourceFile' {
 
     Context 'target file creation fails' {
         
-        $targetFileNames = GetTargetFileNames
-        Mock Test-Path { return $True }
-        Mock Get-TargetFileToUpdate { return $targetFileNames }
-        Mock Set-File { return $False }
-        Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly=$False } }
+        BeforeAll {
+            $targetFileNames = GetTargetFileNames
+            Mock Test-Path { return $True }
+            Mock Get-TargetFileToUpdate { return $targetFileNames }
+            Mock Set-File { return $False }
+            Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly = $False } }
+        }
 
         It 'does not attempt to update target file' {
 
@@ -812,20 +877,22 @@ Describe 'Set-TargetFileFromSourceFile' {
         It 'does not throw an exception' {
 
             { Set-TargetFileFromSourceFile `
-                -SourceFilePath $sourceFilePath `
-                -TargetFileNameList $targetFileNameList `
-                -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -SourceFilePath $sourceFilePath `
+                    -TargetFileNameList $targetFileNameList `
+                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
         }
     }
 
     Context 'target file is read-only' {
         
-        $targetFileNames = GetTargetFileNames
-        Mock Test-Path { return $True }
-        Mock Get-TargetFileToUpdate { return $targetFileNames }
-        Mock Set-File { return $True }
-        Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly=$True } }
-        Mock Copy-Item
+        BeforeAll {
+            $targetFileNames = GetTargetFileNames
+            Mock Test-Path { return $True }
+            Mock Get-TargetFileToUpdate { return $targetFileNames }
+            Mock Set-File { return $True }
+            Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly = $True } }
+            Mock Copy-Item
+        }
 
         It 'does not attempt to update target file' {
 
@@ -839,36 +906,37 @@ Describe 'Set-TargetFileFromSourceFile' {
         It 'does not throw an exception' {
 
             { Set-TargetFileFromSourceFile `
-                -SourceFilePath $sourceFilePath `
-                -TargetFileNameList $targetFileNameList `
-                -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -SourceFilePath $sourceFilePath `
+                    -TargetFileNameList $targetFileNameList `
+                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
         }
     }
 
-    Context 'target file is writable' {
+    Context 'target file is writable' {        
         
-        BeforeEach {
-            $mockSwitches = @{
-                                CheckSourceFileName = $False
-                            }
-        }
-        
-        $targetFileNames = GetTargetFileNames
-        Mock Test-Path { return $True }
-        Mock Get-TargetFileToUpdate { return $targetFileNames }
-        Mock Set-File { return $True }
-        Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly=$False } }
-        Mock Copy-Item {           
-            if ($mockSwitches.CheckSourceFileName)
-            {
-                $copySourceFilePath = $Path
-                if ($copySourceFilePath -ne $sourceFilePath)
+        BeforeAll {
+            $targetFileNames = GetTargetFileNames
+            Mock Test-Path { return $True }
+            Mock Get-TargetFileToUpdate { return $targetFileNames }
+            Mock Set-File { return $True }
+            Mock Get-ChildItem { return  [pscustomobject]@{ IsReadOnly = $False } }
+            Mock Copy-Item {           
+                if ($mockSwitches.CheckSourceFileName)
                 {
-                    throw "Expected source file to be '$sourceFilePath'.  Actual source file is '$copySourceFilePath'."
+                    $copySourceFilePath = $Path
+                    if ($copySourceFilePath -ne $sourceFilePath)
+                    {
+                        throw "Expected source file to be '$sourceFilePath'.  Actual source file is '$copySourceFilePath'."
+                    }
                 }
             }
         }
-
+        
+        BeforeEach {
+            $mockSwitches = @{
+                CheckSourceFileName = $False
+            }
+        }
         It 'updates each target file' {
 
             Set-TargetFileFromSourceFile `
@@ -883,9 +951,9 @@ Describe 'Set-TargetFileFromSourceFile' {
             $mockSwitches.CheckSourceFileName = $True
 
             { Set-TargetFileFromSourceFile `
-                -SourceFilePath $sourceFilePath `
-                -TargetFileNameList $targetFileNameList `
-                -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -SourceFilePath $sourceFilePath `
+                    -TargetFileNameList $targetFileNameList `
+                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
         }
     }
 }

--- a/PesterTests/GitHooksInstaller_FileCopyFunctions.Tests.ps1
+++ b/PesterTests/GitHooksInstaller_FileCopyFunctions.Tests.ps1
@@ -506,8 +506,8 @@ Describe 'Set-TargetFileFromSourceDirectory' {
             Set-TargetFileFromSourceDirectory `
                 -SourceDirectory $sourceDirectoryPath -TargetDirectory $targetDirectoryPath
 
-            Assert-MockCalled Test-Path -Scope It -Times 0 -Exactly
-            Assert-MockCalled Copy-Item -Scope It -Times 0 -Exactly
+            Should -Invoke Test-Path -Scope It -Times 0 -Exactly
+            Should -Invoke Copy-Item -Scope It -Times 0 -Exactly
         }
     }
 
@@ -526,8 +526,8 @@ Describe 'Set-TargetFileFromSourceDirectory' {
             }
             catch {}
 
-            Assert-MockCalled Test-Path -Scope It -Times 1
-            Assert-MockCalled Set-File -Scope It -Times 0 -Exactly
+            Should -Invoke Test-Path -Scope It -Times 1
+            Should -Invoke Set-File -Scope It -Times 0 -Exactly
         }
 
         It 'does not attempt to update target file' {
@@ -539,7 +539,7 @@ Describe 'Set-TargetFileFromSourceDirectory' {
             }
             catch {}
 
-            Assert-MockCalled Set-File -Scope It -Times 0 -Exactly
+            Should -Invoke Set-File -Scope It -Times 0 -Exactly
         }
 
         It 'throws exception' {
@@ -561,7 +561,7 @@ Describe 'Set-TargetFileFromSourceDirectory' {
             Set-TargetFileFromSourceDirectory `
                 -SourceDirectory $sourceDirectoryPath -TargetDirectory $targetDirectoryPath
 
-            Assert-MockCalled Get-ChildItem -Scope It -Times 0 -Exactly
+            Should -Invoke Get-ChildItem -Scope It -Times 0 -Exactly
         }
 
         It 'does not throw an exception' {
@@ -587,7 +587,7 @@ Describe 'Set-TargetFileFromSourceDirectory' {
             Set-TargetFileFromSourceDirectory `
                 -SourceDirectory $sourceDirectoryPath -TargetDirectory $targetDirectoryPath
 
-            Assert-MockCalled Copy-Item -Scope It -Times 0 -Exactly
+            Should -Invoke Copy-Item -Scope It -Times 0 -Exactly
         }
 
         It 'does not throw an exception' {
@@ -610,7 +610,7 @@ Describe 'Set-TargetFileFromSourceDirectory' {
             Set-TargetFileFromSourceDirectory `
                 -SourceDirectory $sourceDirectoryPath -TargetDirectory $targetDirectoryPath
 
-            Assert-MockCalled Copy-Item -Scope It -Times $sourceFileNamesToCopy.Count -Exactly
+            Should -Invoke Copy-Item -Scope It -Times $sourceFileNamesToCopy.Count -Exactly
         }
     }
 
@@ -811,7 +811,7 @@ Describe 'Set-TargetFileFromSourceFile' {
             }
             catch {}
 
-            Assert-MockCalled Test-Path -Scope It -Times 1
+            Should -Invoke Test-Path -Scope It -Times 1
         }
 
         It 'does not attempt to update target files' {
@@ -824,7 +824,7 @@ Describe 'Set-TargetFileFromSourceFile' {
             }
             catch {}
 
-            Assert-MockCalled Get-TargetFileToUpdate -Scope It -Times 0 -Exactly
+            Should -Invoke Get-TargetFileToUpdate -Scope It -Times 0 -Exactly
         }
 
         It 'throws exception' {
@@ -851,7 +851,7 @@ Describe 'Set-TargetFileFromSourceFile' {
                 -SourceFilePath $sourceFilePath `
                 -TargetFileNameList $targetFileNameList -TargetDirectory $targetDirectoryPath
             
-            Assert-MockCalled Set-File -Scope It -Times $targetFileNames.Count -Exactly
+            Should -Invoke Set-File -Scope It -Times $targetFileNames.Count -Exactly
         }
     }
 
@@ -871,7 +871,7 @@ Describe 'Set-TargetFileFromSourceFile' {
                 -SourceFilePath $sourceFilePath `
                 -TargetFileNameList $targetFileNameList -TargetDirectory $targetDirectoryPath
 
-            Assert-MockCalled Get-ChildItem -Scope It -Times 0 -Exactly
+            Should -Invoke Get-ChildItem -Scope It -Times 0 -Exactly
         }
 
         It 'does not throw an exception' {
@@ -900,7 +900,7 @@ Describe 'Set-TargetFileFromSourceFile' {
                 -SourceFilePath $sourceFilePath `
                 -TargetFileNameList $targetFileNameList -TargetDirectory $targetDirectoryPath
 
-            Assert-MockCalled Copy-Item -Scope It -Times 0 -Exactly
+            Should -Invoke Copy-Item -Scope It -Times 0 -Exactly
         }
 
         It 'does not throw an exception' {
@@ -943,7 +943,7 @@ Describe 'Set-TargetFileFromSourceFile' {
                 -SourceFilePath $sourceFilePath `
                 -TargetFileNameList $targetFileNameList -TargetDirectory $targetDirectoryPath
             
-            Assert-MockCalled Copy-Item -Scope It -Times $targetFileNames.Count -Exactly
+            Should -Invoke Copy-Item -Scope It -Times $targetFileNames.Count -Exactly
         }
 
         It 'always copies the same source file' {

--- a/PesterTests/GitHooksInstaller_FileCopyFunctions.Tests.ps1
+++ b/PesterTests/GitHooksInstaller_FileCopyFunctions.Tests.ps1
@@ -546,7 +546,7 @@ Describe 'Set-TargetFileFromSourceDirectory' {
 
             { Set-TargetFileFromSourceDirectory `
                     -SourceDirectory $sourceDirectoryPath `
-                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -WithMessage 'File not found'
+                    -TargetDirectory $targetDirectoryPath } | Should -Throw -ExpectedMessage '*File not found*'
         }
     }
 
@@ -568,7 +568,7 @@ Describe 'Set-TargetFileFromSourceDirectory' {
 
             { Set-TargetFileFromSourceDirectory `
                     -SourceDirectory $sourceDirectoryPath `
-                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -TargetDirectory $targetDirectoryPath } | Should -Not -Throw
         }
     }
 
@@ -594,7 +594,7 @@ Describe 'Set-TargetFileFromSourceDirectory' {
 
             { Set-TargetFileFromSourceDirectory `
                     -SourceDirectory $sourceDirectoryPath `
-                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -TargetDirectory $targetDirectoryPath } | Should -Not -Throw
         }
     }
 
@@ -619,7 +619,7 @@ Describe 'Set-TargetFileFromSourceDirectory' {
         BeforeAll {
             Mock Test-Path { return $True }
             Mock Set-File { return $True }
-            
+
             Mock Copy-Item {
                 $sourceFileFullPath = $Path
                 $targetFileFullPath = $Destination
@@ -637,7 +637,7 @@ Describe 'Set-TargetFileFromSourceDirectory' {
 
             { Set-TargetFileFromSourceDirectory `
                     -SourceDirectory $sourceDirectoryPath `
-                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -TargetDirectory $targetDirectoryPath } | Should -Not -Throw
         }
     }
 }
@@ -666,7 +666,7 @@ Describe 'Get-TargetFileToUpdate' {
             
             { Get-TargetFileToUpdate -SourceFilePath $sourceFilePath `
                     -TargetFileNameList $targetFileNameList -TargetDirectory $targetDirectoryPath } | 
-            Assert-ExceptionThrown -WithMessage 'has no version number'
+                    Should -Throw -ExpectedMessage '*has no version number*'
         }
     }
 
@@ -832,7 +832,7 @@ Describe 'Set-TargetFileFromSourceFile' {
             { Set-TargetFileFromSourceFile `
                     -SourceFilePath $sourceFilePath `
                     -TargetFileNameList $targetFileNameList `
-                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -WithMessage 'not found'
+                    -TargetDirectory $targetDirectoryPath } | Should -Throw -ExpectedMessage '*not found*'
         }
     }
 
@@ -879,7 +879,7 @@ Describe 'Set-TargetFileFromSourceFile' {
             { Set-TargetFileFromSourceFile `
                     -SourceFilePath $sourceFilePath `
                     -TargetFileNameList $targetFileNameList `
-                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -TargetDirectory $targetDirectoryPath } | Should -Not -Throw
         }
     }
 
@@ -908,7 +908,7 @@ Describe 'Set-TargetFileFromSourceFile' {
             { Set-TargetFileFromSourceFile `
                     -SourceFilePath $sourceFilePath `
                     -TargetFileNameList $targetFileNameList `
-                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -TargetDirectory $targetDirectoryPath } | Should -Not -Throw
         }
     }
 
@@ -953,7 +953,7 @@ Describe 'Set-TargetFileFromSourceFile' {
             { Set-TargetFileFromSourceFile `
                     -SourceFilePath $sourceFilePath `
                     -TargetFileNameList $targetFileNameList `
-                    -TargetDirectory $targetDirectoryPath } | Assert-ExceptionThrown -Not
+                    -TargetDirectory $targetDirectoryPath } | Should -Not -Throw
         }
     }
 }

--- a/PesterTests/GitHooksInstaller_GitHookFileFunctions.Tests.ps1
+++ b/PesterTests/GitHooksInstaller_GitHookFileFunctions.Tests.ps1
@@ -199,7 +199,7 @@ Describe 'Find-GitHookDirectory' {
         It 'throws exception' {
 
             { Find-GitHookDirectory -SearchRootDirectory $searchRootDirectory } |
-            Assert-ExceptionThrown -WithMessage 'not found'
+            Should -Throw -ExpectedMessage '*not found*'
         }
     }
 

--- a/PesterTests/GitHooksInstaller_GitHookFileFunctions.Tests.ps1
+++ b/PesterTests/GitHooksInstaller_GitHookFileFunctions.Tests.ps1
@@ -5,189 +5,201 @@ Tests of the functions in the GitHooksInstaller_GitHookFileFunctions.ps1 file.
 .NOTES
 Author:			Simon Elms
 Requires:		PowerShell 5
-                AssertExceptionThrown module (see https://github.com/AnotherSadGit/PesterAssertExceptionThrown)
-Version:		1.0.0
-Date:			5 Jul 2019
+                Pester v5
+Version:		2.0.0
+Date:			2 Jan 2024
 #>
 
-# NOTE: #Requires is not a comment, it's a requires directive.
-#Requires -Modules AssertExceptionThrown
+BeforeAll {
+    # NOTE: The script under test has to be dot sourced in a BeforeAll block, not a 
+    # BeforeDiscovery block.  If placed in a BeforeDiscovery block the tests will fail.
+    # (this is in contrast to importing a module under test, which has to be done in the 
+    # BeforeDiscovery block)
 
-# Can't dot source directly using a simple relative path as relative paths are relative to the 
-# current working directory, not the directory this test file is in.  The current working 
-# directory could be anything.  So Use $PSScriptRoot to get the directory this file is in, and 
-# use a path relative to that.
-. (Join-Path $PSScriptRoot '..\Installer\GitHooksInstaller_GitHookFileFunctions.ps1' -Resolve)
+    # Use $PSScriptRoot so this script will always dot source the script file in the Installer 
+    # folder adjacent to the folder containing this script, regardless of the location that 
+    # Pester is invoked from:
+    #                                     {parent folder}
+    #                                             |
+    #                   -----------------------------------------------------
+    #                   |                                                   |
+    #     {folder containing this script}                                Installer folder
+    #                   |                                                   |
+    #                   |                                                   |
+    #               This script -----------> dot sources ------------->  script file under test
+    . (Join-Path $PSScriptRoot '..\Installer\GitHooksInstaller_GitHookFileFunctions.ps1' -Resolve)
 
-#region Common helper functions *******************************************************************
+    #region Common helper functions *******************************************************************
 
-function GetArrayDisplayText ([array]$Array)
-{
-    if ($Array -eq $Null)
+    function GetArrayDisplayText ([array]$Array)
     {
-        return '[NULL]'
+        if ($Array -eq $Null)
+        {
+            return '[NULL]'
+        }
+
+        if ($Array.Count -eq 0)
+        {
+            return '[EMPTY]'
+        }
+
+        return $Array -join ', '
     }
 
-    if ($Array.Count -eq 0)
+    function AssertArrayMatch ([array]$ExpectedArray, [array]$ActualArray)
     {
-        return '[EMPTY]'
-    }
+        $expectedArrayDisplayText = GetArrayDisplayText $ExpectedArray
+        $actualArrayDisplayText = GetArrayDisplayText $ActualArray
 
-    return $Array -join ', '
-}
+        if ($ExpectedArray -eq $Null)
+        {        
+            if ($ActualArray -eq $Null)
+            {
+                return
+            }
 
-function AssertArrayMatch ([array]$ExpectedArray, [array]$ActualArray)
-{
-    $expectedArrayDisplayText = GetArrayDisplayText $ExpectedArray
-    $actualArrayDisplayText = GetArrayDisplayText $ActualArray
+            throw "Expected array to be [NULL].  Actual value: $actualArrayDisplayText"
+        }
 
-    if ($ExpectedArray -eq $Null)
-    {        
         if ($ActualArray -eq $Null)
+        {
+            throw "Expected array to be $expectedArrayDisplayText.  Was actually [NULL]."
+        }
+
+        $errorMessage = "Expected array to be $expectedArrayDisplayText.  Was actually $actualArrayDisplayText."
+
+        if ($ExpectedArray.Count -ne $ActualArray.Count)
+        {
+            throw $errorMessage
+        }
+
+        # Arrays must each have the same number of elements.
+
+        if ($ExpectedArray.Count -eq 0)
         {
             return
         }
 
-        throw "Expected array to be [NULL].  Actual value: $actualArrayDisplayText"
-    }
-
-    if ($ActualArray -eq $Null)
-    {
-        throw "Expected array to be $expectedArrayDisplayText.  Was actually [NULL]."
-    }
-
-    $errorMessage = "Expected array to be $expectedArrayDisplayText.  Was actually $actualArrayDisplayText."
-
-    if ($ExpectedArray.Count -ne $ActualArray.Count)
-    {
-        throw $errorMessage
-    }
-
-    # Arrays must each have the same number of elements.
-
-    if ($ExpectedArray.Count -eq 0)
-    {
-        return
-    }
-
-    for($i = 0; $i -lt $ExpectedArray.Count; $i++)
-    {
-        if ($ExpectedArray[$i] -ne $ActualArray[$i])
+        for ($i = 0; $i -lt $ExpectedArray.Count; $i++)
         {
-            throw $errorMessage
+            if ($ExpectedArray[$i] -ne $ActualArray[$i])
+            {
+                throw $errorMessage
+            }
         }
     }
-}
 
-function GetSearchRootDirectory
-{
-    return 'TestDrive:\GitDirs'
-}
-
-function GetGitHookTestDirectories
-{
-    return @(
-                'Repo1\.git\hooks'
-                'Repo2\.git\hooks'
-            )
-}
-
-function GetNoHookTestDirectories
-{
-    return @(
-                'NoHooks1\.git'
-                'NoHooks2\.git'
-            )
-}
-
-function GetNoGitTestDirectories
-{
-    return @(
-                'NoGit1\hooks'
-                'NoGit2\hooks'
-            )
-}
-
-function GetTestDirectoryFullPaths(
-    [Switch]$IncludeGitHookDirectories,
-    [Switch]$IncludeNoHookDirectories,
-    [Switch]$IncludeNoGitDirectories
-)
-{
-    $searchRootDirectory = GetSearchRootDirectory
-
-    $relativeDirectories = @()
-    if ($IncludeGitHookDirectories)
+    function GetSearchRootDirectory
     {
-        $directories = GetGitHookTestDirectories
-        $relativeDirectories += $directories
-    }
-    if ($IncludeNoHookDirectories)
-    {
-        $directories = GetNoHookTestDirectories
-        $relativeDirectories += $directories
-    }
-    if ($IncludeNoGitDirectories)
-    {
-        $directories = GetNoGitTestDirectories
-        $relativeDirectories += $directories
+        return 'TestDrive:\GitDirs'
     }
 
-    $relativeDirectories.ForEach{ [pscustomobject]@{ ChildPath=$_ } } | 
-        Join-Path -Path $searchRootDirectory
-}
+    function GetGitHookTestDirectories
+    {
+        return @(
+            'Repo1\.git\hooks'
+            'Repo2\.git\hooks'
+        )
+    }
 
-function GetTestDirectoriesUnderRoot
-{
-    $testDirectories = GetTestDirectoryFullPaths -IncludeGitHookDirectories `
-        -IncludeNoHookDirectories -IncludeNoGitDirectories
-    return $testDirectories
-}
+    function GetNoHookTestDirectories
+    {
+        return @(
+            'NoHooks1\.git'
+            'NoHooks2\.git'
+        )
+    }
 
-function ConvertTestPathToFullPath (
-    [Parameter(
-        Mandatory=$true, 
-        ValueFromPipeline=$true)
-    ]
-    [string] $Path
+    function GetNoGitTestDirectories
+    {
+        return @(
+            'NoGit1\hooks'
+            'NoGit2\hooks'
+        )
+    }
+
+    function GetTestDirectoryFullPaths(
+        [Switch]$IncludeGitHookDirectories,
+        [Switch]$IncludeNoHookDirectories,
+        [Switch]$IncludeNoGitDirectories
     )
-{
-    process
     {
-        return $Path.Replace('TestDrive:', (Get-PSDrive TestDrive).Root)
+        $searchRootDirectory = GetSearchRootDirectory
+
+        $relativeDirectories = @()
+        if ($IncludeGitHookDirectories)
+        {
+            $directories = GetGitHookTestDirectories
+            $relativeDirectories += $directories
+        }
+        if ($IncludeNoHookDirectories)
+        {
+            $directories = GetNoHookTestDirectories
+            $relativeDirectories += $directories
+        }
+        if ($IncludeNoGitDirectories)
+        {
+            $directories = GetNoGitTestDirectories
+            $relativeDirectories += $directories
+        }
+
+        $relativeDirectories.ForEach{ [pscustomobject]@{ ChildPath = $_ } } | 
+        Join-Path -Path $searchRootDirectory
     }
-}
 
-function CreateTestDirectories
-{
-    $searchRootDirectory = GetSearchRootDirectory
-    $directoriesToCreate = GetTestDirectoriesUnderRoot
+    function GetTestDirectoriesUnderRoot
+    {
+        $testDirectories = GetTestDirectoryFullPaths -IncludeGitHookDirectories `
+            -IncludeNoHookDirectories -IncludeNoGitDirectories
+        return $testDirectories
+    }
 
-    $directoriesToCreate.ForEach{ [pscustomobject]@{ Path=$_ } } |
+    function ConvertTestPathToFullPath (
+        [Parameter(
+            Mandatory = $true, 
+            ValueFromPipeline = $true)
+        ]
+        [string] $Path
+    )
+    {
+        process
+        {
+            return $Path.Replace('TestDrive:', (Get-PSDrive TestDrive).Root)
+        }
+    }
+
+    function CreateTestDirectories
+    {
+        $searchRootDirectory = GetSearchRootDirectory
+        $directoriesToCreate = GetTestDirectoriesUnderRoot
+
+        $directoriesToCreate.ForEach{ [pscustomobject]@{ Path = $_ } } |
         New-Item -ItemType Directory
-}
+    }
 
-#endregion
+    #endregion
+}
 
 #region Tests *************************************************************************************
 
 Describe 'Find-GitHookDirectory' {
 
-    # Mock the commands outside the It blocks as a reminder the mocked commands persist into 
-    # subsequent It blocks.
+    BeforeAll {
+        Mock Write-LogMessage
 
-    Mock Write-LogMessage
-
-    $searchRootDirectory = GetSearchRootDirectory
+        $searchRootDirectory = GetSearchRootDirectory
+    }
 
     Context 'search root directory does not exist' {
 
-        Mock Test-Path { return $False }
-
+        BeforeAll {
+            Mock Test-Path { return $False }
+        }
+        
         It 'throws exception' {
 
             { Find-GitHookDirectory -SearchRootDirectory $searchRootDirectory } |
-                Assert-ExceptionThrown -WithMessage 'not found'
+            Assert-ExceptionThrown -WithMessage 'not found'
         }
     }
 
@@ -205,8 +217,10 @@ Describe 'Find-GitHookDirectory' {
 
     Context 'Git hook directories exist under root directory' {
 
-        CreateTestDirectories
-        
+        BeforeAll {
+            CreateTestDirectories
+        }
+
         It 'returns all Git hook directories under root directory' {
 
             $result = Find-GitHookDirectory -SearchRootDirectory $searchRootDirectory | Sort-Object

--- a/PesterTests/GitHooksInstaller_VersionNumberFunctions.Tests.ps1
+++ b/PesterTests/GitHooksInstaller_VersionNumberFunctions.Tests.ps1
@@ -450,7 +450,7 @@ Describe 'Get-DirectoryFileRelativePath' {
         It 'throws an error when directory does not exist' {
 
             { Get-DirectoryFileRelativePath $directoryPath } | 
-            Assert-ExceptionThrown -WithMessage 'does not exist'
+            Should -Throw -ExpectedMessage '*does not exist*'
         }
     }
 
@@ -463,7 +463,7 @@ Describe 'Get-DirectoryFileRelativePath' {
 
         It 'does not throw an error' {
 
-            { Get-DirectoryFileRelativePath $directoryPath } | Assert-ExceptionThrown -Not
+            { Get-DirectoryFileRelativePath $directoryPath } | Should -Not -Throw
         }
 
         It 'resets location to original directory when finishes' {
@@ -494,27 +494,27 @@ Describe 'Get-DirectoryScriptVersion' {
         
         It 'throws error if directory path is Null' {
             { Get-DirectoryScriptVersion -DirectoryPath $Null -FileNameList $fileNameList } | 
-            Assert-ExceptionThrown -WithMessage 'Directory not specified'
+            Should -Throw -ExpectedMessage '*Directory not specified*'
         }
         
         It 'throws error if directory path is empty' {
             { Get-DirectoryScriptVersion -DirectoryPath '' -FileNameList $fileNameList } | 
-            Assert-ExceptionThrown -WithMessage 'Directory not specified'
+            Should -Throw -ExpectedMessage '*Directory not specified*'
         }
         
         It 'throws error if directory path is blank' {
             { Get-DirectoryScriptVersion -DirectoryPath '  ' -FileNameList $fileNameList } | 
-            Assert-ExceptionThrown -WithMessage 'Directory not specified'
+            Should -Throw -ExpectedMessage '*Directory not specified*'
         }
         
         It 'throws error if file name list is Null' {
             { Get-DirectoryScriptVersion -DirectoryPath $directoryPath -FileNameList $Null } | 
-            Assert-ExceptionThrown -WithMessage 'No file names specified'
+            Should -Throw -ExpectedMessage '*No file names specified*'
         }
         
         It 'throws error if file name list is empty' {
             { Get-DirectoryScriptVersion -DirectoryPath $directoryPath -FileNameList @() } | 
-            Assert-ExceptionThrown -WithMessage 'No file names specified'
+            Should -Throw -ExpectedMessage '*No file names specified*'
         }
     }
 

--- a/PesterTests/GitHooksInstaller_VersionNumberFunctions.Tests.ps1
+++ b/PesterTests/GitHooksInstaller_VersionNumberFunctions.Tests.ps1
@@ -5,19 +5,113 @@ Tests of the functions in the GitHooksInstaller_VersionNumberFunctions.ps1 file.
 .NOTES
 Author:			Simon Elms
 Requires:		PowerShell 5
-                AssertExceptionThrown module (see https://github.com/AnotherSadGit/PesterAssertExceptionThrown)
-Date:			1 Jul 2019
-Version:		1.0.0
+                Pester v5
+Date:			30 Dec 2023
+Version:		2.0.0
 #>
 
-# NOTE: #Requires is not a comment, it's a requires directive.
-#Requires -Modules AssertExceptionThrown
+BeforeAll {
+    # NOTE: The script under test has to be dot sourced in a BeforeAll block, not a 
+    # BeforeDiscovery block.  If placed in a BeforeDiscovery block the tests will fail.
+    # (this is in contrast to importing a module under test, which has to be done in the 
+    # BeforeDiscovery block)
 
-# Can't dot source directly using a simple relative path as relative paths are relative to the 
-# current working directory, not the directory this test file is in.  The current working 
-# directory could be anything.  So Use $PSScriptRoot to get the directory this file is in, and 
-# use a path relative to that.
-. (Join-Path $PSScriptRoot '..\Installer\GitHooksInstaller_VersionNumberFunctions.ps1' -Resolve)
+    # Use $PSScriptRoot so this script will always dot source the script file in the Installer 
+    # folder adjacent to the folder containing this script, regardless of the location that 
+    # Pester is invoked from:
+    #                                     {parent folder}
+    #                                             |
+    #                   -----------------------------------------------------
+    #                   |                                                   |
+    #     {folder containing this script}                                Installer folder
+    #                   |                                                   |
+    #                   |                                                   |
+    #               This script -----------> dot sources ------------->  script file under test
+    . (Join-Path $PSScriptRoot '..\Installer\GitHooksInstaller_VersionNumberFunctions.ps1' -Resolve)
+
+    function GetArrayDisplayText ([array]$Array)
+    {
+        if ($Array -eq $Null)
+        {
+            return '[NULL]'
+        }
+    
+        if ($Array.Count -eq 0)
+        {
+            return '[EMPTY]'
+        }
+    
+        return $Array -join ', '
+    }
+    
+    function AssertArrayMatch ([array]$ExpectedArray, [array]$ActualArray)
+    {
+        $expectedArrayDisplayText = GetArrayDisplayText $ExpectedArray
+        $actualArrayDisplayText = GetArrayDisplayText $ActualArray
+    
+        if ($ExpectedArray -eq $Null)
+        {        
+            if ($ActualArray -eq $Null)
+            {
+                return
+            }
+    
+            throw "Expected array to be [NULL].  Actual value: $actualArrayDisplayText"
+        }
+    
+        if ($ActualArray -eq $Null)
+        {
+            throw "Expected array to be $expectedArrayDisplayText.  Was actually [NULL]."
+        }
+    
+        $errorMessage = "Expected array to be $expectedArrayDisplayText.  Was actually $actualArrayDisplayText."
+    
+        if ($ExpectedArray.Count -ne $ActualArray.Count)
+        {
+            throw $errorMessage
+        }
+    
+        # Arrays must each have the same number of elements.
+    
+        if ($ExpectedArray.Count -eq 0)
+        {
+            return
+        }
+    
+        for ($i = 0; $i -lt $ExpectedArray.Count; $i++)
+        {
+            if ($ExpectedArray[$i] -ne $ActualArray[$i])
+            {
+                throw $errorMessage
+            }
+        }
+    }
+
+    function GetRelativeFilePaths
+    {
+        # Need leading '.\' on each file name to match relative paths returned from function under 
+        # test.
+        return @(
+            '.\Test1.txt'
+            '.\Test2.txt'
+            '.\SubDir\Sub1.txt'
+            '.\SubDir\Sub2.txt'
+        ) | Sort-Object # Sort alphabetically to make comparison with actual results easy.
+    }
+
+    function GetFileVersionNumbers ($FilePaths)
+    {
+        $versionNumberArray = @()
+        foreach ($i in 1..$FilePaths.Count)
+        {
+            # Note leading comma.  Without it the array would be unrolled and each element would 
+            # be added separately, resulting in a large 1-D array instead of an array of arrays.
+            $versionNumberArray += , @($i, 0, 0, 0)
+        }
+
+        return $versionNumberArray
+    }
+}
 
 Describe 'Get-VersionArrayDisplayText' {
 
@@ -35,33 +129,36 @@ Describe 'Get-VersionArrayDisplayText' {
     }
 }
 
-function GetRegex ([string]$RegexPattern)
-{
-    $regex = New-Object System.Text.RegularExpressions.Regex($RegexPattern, 
-        [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
-    return $regex
-}
-
-function TestRegexMatch ([string]$TextToSearch, [string]$ExpectedVersionNumber, [System.Text.RegularExpressions.Regex]$Regex)
-{
-    $match = $Regex.Match($TextToSearch)
-
-    $match.Success | Should -Be $True
-    # match has two groups, not one, because the first group is the match 
-    # and the second group is the capture group.
-    $match.Groups.Count | Should -Be 2
-    $match.Groups[1].Value | Should -be $ExpectedVersionNumber
-}
-
-function TestRegexNonMatch ([string]$TextToSearch, [System.Text.RegularExpressions.Regex]$Regex)
-{
-    $match = $Regex.Match($TextToSearch)
-    $match.Success | Should -Be $False
-}
-
 Describe 'VersionNumberRegexPattern' {
-    $regexPattern = Get-VersionNumberRegexPattern
-    $regex = GetRegex -RegexPattern $regexPattern
+
+    BeforeAll {
+        function GetRegex ([string]$RegexPattern)
+        {
+            $regex = New-Object System.Text.RegularExpressions.Regex($RegexPattern, 
+                [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+            return $regex
+        }
+        
+        function TestRegexMatch ([string]$TextToSearch, [string]$ExpectedVersionNumber, [System.Text.RegularExpressions.Regex]$Regex)
+        {
+            $match = $Regex.Match($TextToSearch)
+        
+            $match.Success | Should -Be $True
+            # match has two groups, not one, because the first group is the match 
+            # and the second group is the capture group.
+            $match.Groups.Count | Should -Be 2
+            $match.Groups[1].Value | Should -be $ExpectedVersionNumber
+        }
+        
+        function TestRegexNonMatch ([string]$TextToSearch, [System.Text.RegularExpressions.Regex]$Regex)
+        {
+            $match = $Regex.Match($TextToSearch)
+            $match.Success | Should -Be $False
+        }
+
+        $regexPattern = Get-VersionNumberRegexPattern
+        $regex = GetRegex -RegexPattern $regexPattern
+    }
     
     It 'does not match empty string' {
         TestRegexNonMatch -TextToSearch '' -Regex $regex
@@ -142,17 +239,18 @@ Describe 'VersionNumberRegexPattern' {
 
 Describe 'Get-ScriptFileVersionString' {
 
-    # Mock the commands outside the It blocks as a reminder the mocked commands persist into 
-    # subsequent It blocks.
-
-    Mock Write-LogMessage 
+    BeforeAll {
+        Mock Write-LogMessage 
         
-    $testFilePath = 'C:\TestFile.txt'
-    $allZeroVersionString = '0.0.0.0'
-    $highValuedVersionString = '99999.0.0.0'
+        $testFilePath = 'C:\TestFile.txt'
+        $allZeroVersionString = '0.0.0.0'
+        $highValuedVersionString = '99999.0.0.0'
+    }
 
     Context 'file not found' {
-        Mock Test-Path { return $False }
+        BeforeAll {
+            Mock Test-Path { return $False }
+        }
 
         It 'returns all-zero version string' {
             Get-ScriptFileVersionString $testFilePath | Should -Be $allZeroVersionString
@@ -160,8 +258,10 @@ Describe 'Get-ScriptFileVersionString' {
     }    
 
     Context 'file found but no version number' {
-        Mock Test-Path { return $True }
-        Mock Select-String { return @() }
+        BeforeAll {
+            Mock Test-Path { return $True }
+            Mock Select-String { return @() }
+        }
 
         It 'returns high-valued version string' {
             Get-ScriptFileVersionString $testFilePath | Should -Be $highValuedVersionString
@@ -169,15 +269,17 @@ Describe 'Get-ScriptFileVersionString' {
     }        
 
     Context 'version number found but no group captured' {
-        Mock Test-Path { return $True }
-        Mock Select-String { 
-            # Want a match without a capture group.
-            $match = [System.Text.RegularExpressions.Regex]::Match('xxx', 'xxx')
+        BeforeAll {
+            Mock Test-Path { return $True }
+            Mock Select-String { 
+                # Want a match without a capture group.
+                $match = [System.Text.RegularExpressions.Regex]::Match('xxx', 'xxx')
 
-            $matchInfo = New-Object PSObject | 
+                $matchInfo = New-Object PSObject | 
                 Add-Member -MemberType NoteProperty -Name Matches -Value @( $match ) -PassThru
 
-            return $matchInfo
+                return $matchInfo
+            }
         }
 
         It 'returns high-valued version string' {
@@ -190,15 +292,18 @@ Describe 'Get-ScriptFileVersionString' {
     }           
 
     Context 'version number found and group captured' {
-        Mock Test-Path { return $True }
-        Mock Select-String { 
-            # Want a match with a capture group.
-            $match = [System.Text.RegularExpressions.Regex]::Match('A number: 42', '(\d\d)')
 
-            $matchInfo = New-Object PSObject | 
+        BeforeAll {
+            Mock Test-Path { return $True }
+            Mock Select-String { 
+                # Want a match with a capture group.
+                $match = [System.Text.RegularExpressions.Regex]::Match('A number: 42', '(\d\d)')
+
+                $matchInfo = New-Object PSObject | 
                 Add-Member -MemberType NoteProperty -Name Matches -Value @( $match ) -PassThru
 
-            return $matchInfo
+                return $matchInfo
+            }
         }
 
         It 'returns version string' {
@@ -209,92 +314,34 @@ Describe 'Get-ScriptFileVersionString' {
     } 
 }
 
-function GetArrayDisplayText ([array]$Array)
-{
-    if ($Array -eq $Null)
-    {
-        return '[NULL]'
-    }
-
-    if ($Array.Count -eq 0)
-    {
-        return '[EMPTY]'
-    }
-
-    return $Array -join ', '
-}
-
-function AssertArrayMatch ([array]$ExpectedArray, [array]$ActualArray)
-{
-    $expectedArrayDisplayText = GetArrayDisplayText $ExpectedArray
-    $actualArrayDisplayText = GetArrayDisplayText $ActualArray
-
-    if ($ExpectedArray -eq $Null)
-    {        
-        if ($ActualArray -eq $Null)
-        {
-            return
-        }
-
-        throw "Expected array to be [NULL].  Actual value: $actualArrayDisplayText"
-    }
-
-    if ($ActualArray -eq $Null)
-    {
-        throw "Expected array to be $expectedArrayDisplayText.  Was actually [NULL]."
-    }
-
-    $errorMessage = "Expected array to be $expectedArrayDisplayText.  Was actually $actualArrayDisplayText."
-
-    if ($ExpectedArray.Count -ne $ActualArray.Count)
-    {
-        throw $errorMessage
-    }
-
-    # Arrays must each have the same number of elements.
-
-    if ($ExpectedArray.Count -eq 0)
-    {
-        return
-    }
-
-    for($i = 0; $i -lt $ExpectedArray.Count; $i++)
-    {
-        if ($ExpectedArray[$i] -ne $ActualArray[$i])
-        {
-            throw $errorMessage
-        }
-    }
-}
-
 Describe 'Convert-VersionNumberStringToArray' {
-    
-    # Mock the commands outside the It blocks as a reminder the mocked commands persist into 
-    # subsequent It blocks.
+    BeforeAll {
 
-    Mock Write-LogMessage 
-    
-    $defaultVersionArray = @(99999, 0, 0, 0)
-
-    function AssertCorrectArrayReturned (
-        [array]$ExpectedArray, 
-        [array]$ActualArray, 
-        [string]$LogMessagePattern
-    )
-    {
-        # Will throw exception if arrays don't match.
-        AssertArrayMatch $ExpectedArray $ActualArray
-
-        if (-not [string]::IsNullOrWhiteSpace($LogMessagePattern))
+        function AssertCorrectArrayReturned (
+            [array]$ExpectedArray, 
+            [array]$ActualArray, 
+            [string]$LogMessagePattern
+        )
         {
-            Assert-MockCalled Write-LogMessage -Scope It -Times 1 `
-                -ParameterFilter { $Message -like $LogMessagePattern } 
+            # Will throw exception if arrays don't match.
+            AssertArrayMatch $ExpectedArray $ActualArray
+    
+            if (-not [string]::IsNullOrWhiteSpace($LogMessagePattern))
+            {
+                Assert-MockCalled Write-LogMessage -Scope It -Times 1 `
+                    -ParameterFilter { $Message -like $LogMessagePattern } 
+            }
         }
+
+        Mock Write-LogMessage 
+        
+        $defaultVersionArray = @(99999, 0, 0, 0)
     }
 
-    Context 'version number string not supplied' {
-        
-        $errorMessagePattern = 'No version number supplied*'
+    Context 'version number string not supplied' {        
+        BeforeAll {
+            $errorMessagePattern = 'No version number supplied*'
+        }
 
         It 'returns default array when version string is empty' {
             $result = Convert-VersionNumberStringToArray ''
@@ -310,8 +357,9 @@ Describe 'Convert-VersionNumberStringToArray' {
     }
 
     Context 'version number string contains non-numeric' {
-
-        $errorMessagePattern = 'Invalid, non-numeric, version number*'
+        BeforeAll {
+            $errorMessagePattern = 'Invalid, non-numeric, version number*'
+        }
 
         It 'returns default array when version string is single non-numeric "word"' {
             $result = Convert-VersionNumberStringToArray 'ab'
@@ -355,87 +403,63 @@ Describe 'Convert-VersionNumberStringToArray' {
         It 'returns array matching valid four-part version number string' {
             $result = Convert-VersionNumberStringToArray '1.2.3.4'
 
-            AssertCorrectArrayReturned @(1,2,3,4) $result
+            AssertCorrectArrayReturned @(1, 2, 3, 4) $result
         }
 
         It 'returns array without error when version numbers in string had leading zeros' {
             $result = Convert-VersionNumberStringToArray '01.02.03.04'
 
-            AssertCorrectArrayReturned @(1,2,3,4) $result
+            AssertCorrectArrayReturned @(1, 2, 3, 4) $result
         }
 
         It 'returns four-part array padded with trailing zeros for two-part version number string' {
             $result = Convert-VersionNumberStringToArray '1.2'
 
-            AssertCorrectArrayReturned @(1,2,0,0) $result
+            AssertCorrectArrayReturned @(1, 2, 0, 0) $result
         }
 
         It 'returns four-part array matching the first four parts of a five-part version number string' {
             $result = Convert-VersionNumberStringToArray '1.2.3.4.5'
 
-            AssertCorrectArrayReturned @(1,2,3,4) $result
+            AssertCorrectArrayReturned @(1, 2, 3, 4) $result
         }
     }
 }
 
-function CreateEmptyTestFiles ([string]$RootDirectoryPath, [array]$FileNames)
-{    
-    $objectArray = @()
-    $FileNames.ForEach{ $objectArray += [pscustomobject]@{ ChildPath=$_ } }
-    $fileFullPaths = $objectArray | Join-Path -Path $RootDirectoryPath 
-    New-Item -ItemType File -Path $fileFullPaths -Force
-}
-
-function GetRelativeFilePaths
-{
-    # Need leading '.\' on each file name to match relative paths returned from function under 
-    # test.
-    return @(
-                '.\Test1.txt'
-                '.\Test2.txt'
-                '.\SubDir\Sub1.txt'
-                '.\SubDir\Sub2.txt'
-            ) | Sort-Object # Sort alphabetically to make comparison with actual results easy.
-}
-
-function GetFileVersionNumbers ($FilePaths)
-{
-    $versionNumberArray = @()
-    foreach($i in 1..$FilePaths.Count)
-    {
-        # Note leading comma.  Without it the array would be unrolled and each element would 
-        # be added separately, resulting in a large 1-D array instead of an array of arrays.
-        $versionNumberArray += ,@($i,0,0,0)
-    }
-
-    return $versionNumberArray
-}
-
 Describe 'Get-DirectoryFileRelativePath' {
-    
-    # Mock the commands outside the It blocks as a reminder the mocked commands persist into 
-    # subsequent It blocks.
 
-    Mock Write-LogMessage 
+    BeforeAll {       
 
-    $directoryPath = 'TestDrive:\TestDir'
+        function CreateEmptyTestFiles ([string]$RootDirectoryPath, [array]$FileNames)
+        {    
+            $objectArray = @()
+            $FileNames.ForEach{ $objectArray += [pscustomobject]@{ ChildPath = $_ } }
+            $fileFullPaths = $objectArray | Join-Path -Path $RootDirectoryPath 
+            New-Item -ItemType File -Path $fileFullPaths -Force
+        }
+
+        Mock Write-LogMessage 
+
+        $directoryPath = 'TestDrive:\TestDir'
     
-    $fileRelativePaths = GetRelativeFilePaths
+        $fileRelativePaths = GetRelativeFilePaths
+    }
 
     Context 'directory does not exist' {
 
         It 'throws an error when directory does not exist' {
 
             { Get-DirectoryFileRelativePath $directoryPath } | 
-                Assert-ExceptionThrown -WithMessage 'does not exist'
+            Assert-ExceptionThrown -WithMessage 'does not exist'
         }
     }
 
     Context 'directory exists' {
-        
-        CreateEmptyTestFiles -RootDirectoryPath $directoryPath -FileNames $fileRelativePaths
+        BeforeAll { 
+            CreateEmptyTestFiles -RootDirectoryPath $directoryPath -FileNames $fileRelativePaths
 
-        $originalPath = $pwd.Path
+            $originalPath = $pwd.Path
+        }
 
         It 'does not throw an error' {
 
@@ -458,56 +482,56 @@ Describe 'Get-DirectoryFileRelativePath' {
 }
 
 Describe 'Get-DirectoryScriptVersion' {
-    
-    # Mock the commands outside the It blocks as a reminder the mocked commands persist into 
-    # subsequent It blocks.
+    BeforeAll { 
+        Mock Write-LogMessage 
 
-    Mock Write-LogMessage 
-
-    $directoryPath = 'TestDrive:\TestDir'
+        $directoryPath = 'TestDrive:\TestDir'
     
-    $fileRelativePaths = GetRelativeFilePaths
+        $fileRelativePaths = GetRelativeFilePaths
+    }
 
     Context 'inputs not supplied' {
         
         It 'throws error if directory path is Null' {
             { Get-DirectoryScriptVersion -DirectoryPath $Null -FileNameList $fileNameList } | 
-                Assert-ExceptionThrown -WithMessage 'Directory not specified'
+            Assert-ExceptionThrown -WithMessage 'Directory not specified'
         }
         
         It 'throws error if directory path is empty' {
             { Get-DirectoryScriptVersion -DirectoryPath '' -FileNameList $fileNameList } | 
-                Assert-ExceptionThrown -WithMessage 'Directory not specified'
+            Assert-ExceptionThrown -WithMessage 'Directory not specified'
         }
         
         It 'throws error if directory path is blank' {
             { Get-DirectoryScriptVersion -DirectoryPath '  ' -FileNameList $fileNameList } | 
-                Assert-ExceptionThrown -WithMessage 'Directory not specified'
+            Assert-ExceptionThrown -WithMessage 'Directory not specified'
         }
         
         It 'throws error if file name list is Null' {
             { Get-DirectoryScriptVersion -DirectoryPath $directoryPath -FileNameList $Null } | 
-                Assert-ExceptionThrown -WithMessage 'No file names specified'
+            Assert-ExceptionThrown -WithMessage 'No file names specified'
         }
         
         It 'throws error if file name list is empty' {
             { Get-DirectoryScriptVersion -DirectoryPath $directoryPath -FileNameList @() } | 
-                Assert-ExceptionThrown -WithMessage 'No file names specified'
+            Assert-ExceptionThrown -WithMessage 'No file names specified'
         }
     }
 
     Context 'inputs supplied' {
         
-        BeforeEach {
-            $mockState = @{
-                            VersionNumber = 0    
-                        }
+        BeforeAll { 
+            Mock Get-ScriptFileVersion {
+                $mockState.VersionNumber++
+    
+                return @($mockState.VersionNumber, 0, 0, 0)
+            }        
         }
 
-        Mock Get-ScriptFileVersion {
-            $mockState.VersionNumber++
-
-            return @($mockState.VersionNumber,0,0,0)
+        BeforeEach {
+            $mockState = @{
+                VersionNumber = 0    
+            }
         }
 
         It 'returns hash table with relative file paths as the keys' {
@@ -542,31 +566,30 @@ Describe 'Get-DirectoryScriptVersion' {
 
             # Cannot get a value from the hash table Values collection via an index.  So iterate through them.
             $i = 0
-            foreach($resultValue in $resultVersionNumberCollection)
+            foreach ($resultValue in $resultVersionNumberCollection)
             {
-                 AssertArrayMatch -ExpectedArray $expectedVersionNumberArrays[$i] -ActualArray $resultValue
+                AssertArrayMatch -ExpectedArray $expectedVersionNumberArrays[$i] -ActualArray $resultValue
                 $i++
             }       
         }
     }
 }
 
-function AssertVersionArrayComparisonResult (
-    [array]$LeftVersionArray,
-    [array]$RightVersionArray, 
-    [string]$ExpectedResult
-    )
-{
-    $result = Compare-Version $LeftVersionArray $RightVersionArray
-    $result | Should -Be $ExpectedResult
-}
-
 Describe 'Compare-Version' {
     
-    # Mock the commands outside the It blocks as a reminder the mocked commands persist into 
-    # subsequent It blocks.
+    BeforeAll {
+        function AssertVersionArrayComparisonResult (
+            [array]$LeftVersionArray,
+            [array]$RightVersionArray, 
+            [string]$ExpectedResult
+        )
+        {
+            $result = Compare-Version $LeftVersionArray $RightVersionArray
+            $result | Should -Be $ExpectedResult
+        }
 
-    Mock Write-LogMessage
+        Mock Write-LogMessage
+    }
 
     It 'returns "=" when both version arrays are Null' {
         AssertVersionArrayComparisonResult $Null $Null '='
@@ -585,70 +608,70 @@ Describe 'Compare-Version' {
     }
 
     It 'returns "<" when left version array is Null and right array is populated' {
-        AssertVersionArrayComparisonResult $Null @(1,2,3,4) '<'
+        AssertVersionArrayComparisonResult $Null @(1, 2, 3, 4) '<'
     }
 
     It 'returns "<" when left version array is empty and right array is populated' {
-        AssertVersionArrayComparisonResult @() @(1,2,3,4) '<'
+        AssertVersionArrayComparisonResult @() @(1, 2, 3, 4) '<'
     }
 
     It 'returns ">" when left version array is populated and right array is Null' {
-        AssertVersionArrayComparisonResult @(1,2,3,4) $Null '>'
+        AssertVersionArrayComparisonResult @(1, 2, 3, 4) $Null '>'
     }
 
     It 'returns ">" when left version array is populated and right array is empty' {
-        AssertVersionArrayComparisonResult @(1,2,3,4) @() '>'
+        AssertVersionArrayComparisonResult @(1, 2, 3, 4) @() '>'
     }
 
     It 'returns "=" when both version arrays are populated and identical' {
-        AssertVersionArrayComparisonResult @(1,2,3,4) @(1,2,3,4) '='
+        AssertVersionArrayComparisonResult @(1, 2, 3, 4) @(1, 2, 3, 4) '='
     }
 
     It 'returns "<" when first element of left array is less than first element of right array' {
-        AssertVersionArrayComparisonResult @(1,2,3,4) @(2,2,3,4) '<'
+        AssertVersionArrayComparisonResult @(1, 2, 3, 4) @(2, 2, 3, 4) '<'
     }
 
     It 'returns "<" when left[0] < right[0] even if other elements of left are greater than right' {
-        AssertVersionArrayComparisonResult @(1,9,8,7) @(2,2,3,4) '<'
+        AssertVersionArrayComparisonResult @(1, 9, 8, 7) @(2, 2, 3, 4) '<'
     }
 
     It 'returns ">" when first element of left array is greater than first element of right array' {
-        AssertVersionArrayComparisonResult @(2,2,3,4) @(1,2,3,4) '>'
+        AssertVersionArrayComparisonResult @(2, 2, 3, 4) @(1, 2, 3, 4) '>'
     }
 
     It 'returns ">" when left[0] > right[0] even if other elements of left are less than right' {
-        AssertVersionArrayComparisonResult @(2,2,3,4) @(1,9,8,7) '>'
+        AssertVersionArrayComparisonResult @(2, 2, 3, 4) @(1, 9, 8, 7) '>'
     }
 
     It 'returns "<" when second element of left array is less than second element of right array' {
-        AssertVersionArrayComparisonResult @(1,1,3,4) @(1,2,3,4) '<'
+        AssertVersionArrayComparisonResult @(1, 1, 3, 4) @(1, 2, 3, 4) '<'
     }
 
     It 'returns "<" when left[1] < right[1] even if subsequent elements of left are greater than right' {
-        AssertVersionArrayComparisonResult @(1,1,8,7) @(1,2,3,4) '<'
+        AssertVersionArrayComparisonResult @(1, 1, 8, 7) @(1, 2, 3, 4) '<'
     }
 
     It 'returns ">" when second element of left array is greater than second element of right array' {
-        AssertVersionArrayComparisonResult @(1,2,3,4) @(1,1,3,4) '>'
+        AssertVersionArrayComparisonResult @(1, 2, 3, 4) @(1, 1, 3, 4) '>'
     }
 
     It 'returns ">" when left[1] > right[1] even if other elements of left are less than right' {
-        AssertVersionArrayComparisonResult @(1,2,3,4) @(1,1,8,7) '>'
+        AssertVersionArrayComparisonResult @(1, 2, 3, 4) @(1, 1, 8, 7) '>'
     }
 
     It 'returns "<" when last element of left array is less than last element of right array' {
-        AssertVersionArrayComparisonResult @(1,2,3,1) @(1,2,3,4) '<'
+        AssertVersionArrayComparisonResult @(1, 2, 3, 1) @(1, 2, 3, 4) '<'
     }
 
     It 'returns ">" when last element of left array is greater than last element of right array' {
-        AssertVersionArrayComparisonResult @(1,2,3,4) @(1,2,3,1) '>'
+        AssertVersionArrayComparisonResult @(1, 2, 3, 4) @(1, 2, 3, 1) '>'
     }
 
     It 'returns "<" when equivalent elements in the arrays are identical but left array has less elements than right' {
-        AssertVersionArrayComparisonResult @(1,2,3) @(1,2,3,4) '<'
+        AssertVersionArrayComparisonResult @(1, 2, 3) @(1, 2, 3, 4) '<'
     }
 
     It 'returns ">" when equivalent elements in the arrays are identical but left array has more elements than right' {
-        AssertVersionArrayComparisonResult @(1,2,3,4) @(1,2,3) '>'
+        AssertVersionArrayComparisonResult @(1, 2, 3, 4) @(1, 2, 3) '>'
     }
 }

--- a/PesterTests/GitHooksInstaller_VersionNumberFunctions.Tests.ps1
+++ b/PesterTests/GitHooksInstaller_VersionNumberFunctions.Tests.ps1
@@ -286,7 +286,7 @@ Describe 'Get-ScriptFileVersionString' {
             $result = Get-ScriptFileVersionString $testFilePath 
 
             $result | Should -Be $highValuedVersionString
-            Assert-MockCalled Write-LogMessage -Scope It -Times 1 `
+            Should -Invoke Write-LogMessage -Scope It -Times 1 `
                 -ParameterFilter { $Message -like 'No capture group found for regex*' } 
         }
     }           
@@ -328,7 +328,7 @@ Describe 'Convert-VersionNumberStringToArray' {
     
             if (-not [string]::IsNullOrWhiteSpace($LogMessagePattern))
             {
-                Assert-MockCalled Write-LogMessage -Scope It -Times 1 `
+                Should -Invoke Write-LogMessage -Scope It -Times 1 `
                     -ParameterFilter { $Message -like $LogMessagePattern } 
             }
         }

--- a/PesterTests/GitHooksInstalller_HelperFunctions.Tests.ps1
+++ b/PesterTests/GitHooksInstalller_HelperFunctions.Tests.ps1
@@ -164,7 +164,7 @@ Describe 'Install-RequiredModule' {
             $mockState.ModuleExistsInRepository = $False
 
             { ExecuteInstallRequiredModule } | 
-            Assert-ExceptionThrown -WithMessage 'not found in repository'
+            Should -Throw -ExpectedMessage '*not found in repository*'
         }
 
         It 'attempts to install module for current user when module found in repository' {
@@ -208,7 +208,7 @@ Describe 'Install-RequiredModule' {
             $mockState.InstallWithoutProxySucceeds = $False
 
             { ExecuteInstallRequiredModule } | 
-            Assert-ExceptionThrown -WithMessage 'Unknown error installing module'
+            Should -Throw -ExpectedMessage '*Unknown error installing module*'
         }
 
         It 'does not throw exception when module is listed in installed modules after installation' {
@@ -216,7 +216,7 @@ Describe 'Install-RequiredModule' {
             $mockState.ModuleExistsInRepository = $True
             $mockState.InstallWithoutProxySucceeds = $True
 
-            { ExecuteInstallRequiredModule } | Assert-ExceptionThrown -Not
+            { ExecuteInstallRequiredModule } | Should -Not -Throw
         }
     }
 
@@ -262,7 +262,7 @@ Describe 'Install-RequiredModule' {
             $mockState.InstallWithProxyRaisesError = $True
             
             { ExecuteInstallRequiredModule } | 
-            Assert-ExceptionThrown -WithMessage 'Error in second installation attempt'
+            Should -Throw -ExpectedMessage '*Error in second installation attempt*'
         }
 
         It 'throws exception when module is not listed in installed modules after module installation' {
@@ -274,7 +274,7 @@ Describe 'Install-RequiredModule' {
             $mockState.InstallWithProxySucceeds = $False
 
             { ExecuteInstallRequiredModule } | 
-            Assert-ExceptionThrown -WithMessage 'Unknown error installing module'
+            Should -Throw -ExpectedMessage '*Unknown error installing module*'
         }
 
         It 'does not throw exception when module is listed in installed modules after installation' {
@@ -283,7 +283,7 @@ Describe 'Install-RequiredModule' {
             $mockState.InstallWithoutProxyRaisesError = $True
             $mockState.InstallWithProxySucceeds = $True
 
-            { ExecuteInstallRequiredModule } | Assert-ExceptionThrown -Not
+            { ExecuteInstallRequiredModule } | Should -Not -Throw
         }
     }
 }

--- a/PesterTests/GitHooksInstalller_HelperFunctions.Tests.ps1
+++ b/PesterTests/GitHooksInstalller_HelperFunctions.Tests.ps1
@@ -127,8 +127,8 @@ Describe 'Install-RequiredModule' {
             ExecuteInstallRequiredModule
 
             # Find-Module should not be called because it should exit before then.
-            Assert-MockCalled Find-Module -Scope It -Times 0 -Exactly
-            Assert-MockCalled Install-Module -Scope It -Times 0 -Exactly
+            Should -Invoke Find-Module -Scope It -Times 0 -Exactly
+            Should -Invoke Install-Module -Scope It -Times 0 -Exactly
         } 
     }
 
@@ -139,7 +139,7 @@ Describe 'Install-RequiredModule' {
 
             ExecuteInstallRequiredModule
 
-            Assert-MockCalled Set-PSRepository -Scope It -Times 0 -Exactly
+            Should -Invoke Set-PSRepository -Scope It -Times 0 -Exactly
         }
 
         It 'sets repository installation policy to Trusted when repository is untrusted' {
@@ -147,7 +147,7 @@ Describe 'Install-RequiredModule' {
 
             ExecuteInstallRequiredModule
 
-            Assert-MockCalled Set-PSRepository -Scope It -Times 1 -Exactly `
+            Should -Invoke Set-PSRepository -Scope It -Times 1 -Exactly `
                 -ParameterFilter { $InstallationPolicy -eq 'Trusted' }
         }
 
@@ -156,7 +156,7 @@ Describe 'Install-RequiredModule' {
 
             ExecuteInstallRequiredModule
 
-            Assert-MockCalled Find-Module -Scope It -Times 1 -Exactly
+            Should -Invoke Find-Module -Scope It -Times 1 -Exactly
         }
 
         It 'throws exception when module does not exist in repository' {
@@ -174,7 +174,7 @@ Describe 'Install-RequiredModule' {
 
             ExecuteInstallRequiredModule
 
-            Assert-MockCalled Install-Module -Scope It -Times 1 -Exactly `
+            Should -Invoke Install-Module -Scope It -Times 1 -Exactly `
                 -ParameterFilter { $Scope -eq 'CurrentUser' }
         }
     }
@@ -188,7 +188,7 @@ Describe 'Install-RequiredModule' {
 
             ExecuteInstallRequiredModule
 
-            Assert-MockCalled Install-Module -Scope It -Times 1 -Exactly
+            Should -Invoke Install-Module -Scope It -Times 1 -Exactly
         }
 
         It 'checks whether module listed in installed modules after module installation' {
@@ -198,8 +198,8 @@ Describe 'Install-RequiredModule' {
 
             ExecuteInstallRequiredModule
 
-            Assert-MockCalled Install-Module -Scope It -Times 1 -Exactly
-            Assert-MockCalled Get-InstalledModule -Scope It -Times 2 -Exactly
+            Should -Invoke Install-Module -Scope It -Times 1 -Exactly
+            Should -Invoke Get-InstalledModule -Scope It -Times 2 -Exactly
         }
 
         It 'throws exception when module is not listed in installed modules after module installation' {
@@ -229,7 +229,7 @@ Describe 'Install-RequiredModule' {
 
             ExecuteInstallRequiredModule
 
-            Assert-MockCalled Install-Module -Scope It -Times 2 -Exactly
+            Should -Invoke Install-Module -Scope It -Times 2 -Exactly
         }
 
         It 'installs module for current user only on second installation attempt' {
@@ -239,7 +239,7 @@ Describe 'Install-RequiredModule' {
 
             ExecuteInstallRequiredModule
 
-            Assert-MockCalled Install-Module -Scope It -Times 2 -Exactly `
+            Should -Invoke Install-Module -Scope It -Times 2 -Exactly `
                 -ParameterFilter { $Scope -eq 'CurrentUser' }
         }
 
@@ -251,7 +251,7 @@ Describe 'Install-RequiredModule' {
             ExecuteInstallRequiredModule
 
             $proxyUrl = GetProxyUrl
-            Assert-MockCalled Install-Module -Scope It -Times 1 -Exactly `
+            Should -Invoke Install-Module -Scope It -Times 1 -Exactly `
                 -ParameterFilter { $Proxy -eq $proxyUrl -and $ProxyCredential -ne $Null }
         }
 
@@ -305,13 +305,13 @@ Describe 'Set-File' {
 
         It 'calls Test-Path' {
             Set-File $testFilePath
-            Assert-MockCalled Test-Path -Scope It -Times 1 -Exactly
+            Should -Invoke Test-Path -Scope It -Times 1 -Exactly
         }
 
         It 'does not call New-Item' {
             Set-File $testFilePath
 
-            Assert-MockCalled New-Item -Scope It -Times 0 -Exactly
+            Should -Invoke New-Item -Scope It -Times 0 -Exactly
         }
 
         It 'returns FileInfo object' {
@@ -327,12 +327,12 @@ Describe 'Set-File' {
         
         It 'calls Test-Path' {
             Set-File $testFilePath
-            Assert-MockCalled Test-Path -Scope It -Times 1 -Exactly
+            Should -Invoke Test-Path -Scope It -Times 1 -Exactly
         }
 
         It 'calls New-Item' {
             Set-File $testFilePath
-            Assert-MockCalled New-Item -Scope It -Times 1 -Exactly
+            Should -Invoke New-Item -Scope It -Times 1 -Exactly
         }
 
         It 'returns Null' {
@@ -373,12 +373,12 @@ Describe 'Set-File' {
         
         It 'calls Test-Path' {
             Set-File $testFilePath
-            Assert-MockCalled Test-Path -Scope It -Times 1 -Exactly
+            Should -Invoke Test-Path -Scope It -Times 1 -Exactly
         }
 
         It 'calls New-Item' {
             Set-File $testFilePath
-            Assert-MockCalled New-Item -Scope It -Times 1 -Exactly
+            Should -Invoke New-Item -Scope It -Times 1 -Exactly
         }
 
         It 'returns FileInfo object' {

--- a/PesterTests/InvokeTests.txt
+++ b/PesterTests/InvokeTests.txt
@@ -1,0 +1,38 @@
+Pester v5
+=========
+$testFolder = 'C:\...\PowerShell\Modules\GitHooks\PesterTests'
+
+---------------
+# Run all tests
+---------------
+Invoke-Pester $testFolder -Output Detailed
+
+--------------------------
+# Run specified test files
+--------------------------
+Invoke-Pester "${testFolder}\GitHooksInstalller_HelperFunctions.Tests.ps1" -Output Detailed
+
+Invoke-Pester "${testFolder}\GitHooksInstaller_VersionNumberFunctions.Tests.ps1" -Output Detailed
+
+Invoke-Pester "${testFolder}\GitHooksInstaller_FileCopyFunctions.Tests.ps1" -Output Detailed
+
+Invoke-Pester "${testFolder}\GitHooksInstaller_GitHookFileFunctions.Tests.ps1" -Output Detailed
+
+-----------------------------------------------------
+# Run specified Describe block in specified test file
+-----------------------------------------------------
+# -FullNameFilter can only take the name of a Describe block, not a Context or It block
+Invoke-Pester "${testFolder}\GitHooksInstalller_HelperFunctions.Tests.ps1" -FullNameFilter 'Set-File' -Output Detailed
+
+# or:
+$config = New-PesterConfiguration
+$config.Run.Path = "${testFolder}\GitHooksInstalller_HelperFunctions.Tests.ps1"
+$config.Filter.FullName = 'Set-File'
+Invoke-Pester -Configuration $config
+
+---------------------------------------------
+# Run specified Context or It blocks via Tags
+---------------------------------------------
+# EG in test file:
+#	Context 'Parameter set "AllSettings"' -Tag 'RunThis' { ... }
+Invoke-Pester "${testFolder}\GitHooksInstalller_HelperFunctions.Tests.ps1" -Tag 'RunThis', 'RunThat' -Output Detailed


### PR DESCRIPTION
Update Pester tests to work with Pester v5.

Also include issue #4 to allow Pester tests to run without needing Admin privileges.