### PR TITLE
Feature/issue 002 parent plus child issue numbers

### DIFF
--- a/GitHookSourceFilesToCopy/CommonGitHooks/PowerShellHooks/CommonFunctions.psm1
+++ b/GitHookSourceFilesToCopy/CommonGitHooks/PowerShellHooks/CommonFunctions.psm1
@@ -50,13 +50,21 @@ function Write-OutputMessage (
         $MessageHeader = Get-MessageHeader
     }
 
-    if ([string]::IsNullOrWhiteSpace($MessageHeader))
+    $rawHeader = $MessageHeader
+
+    if ([string]::IsNullOrWhiteSpace($rawHeader))
     {
-        $MessageHeader = ''
+        $rawHeader = ''
     }
     else
     {
-        $MessageHeader = "$($MessageHeader.Trim()): "
+        $rawHeader = $MessageHeader.Trim()
+    }
+
+    $MessageHeader = $rawHeader
+    if ($MessageHeader)
+    {
+        $MessageHeader = "$($MessageHeader): "
     }
 
     if ($Message -is [string])
@@ -80,7 +88,15 @@ function Write-OutputMessage (
 
                 if ($WriteFirstLineOnly)
                 {
-                    Write-Output "$MessageHeader  ..."
+                    if ($MessageHeader)
+                    {
+                        Write-Output "$MessageHeader..."
+                    }
+                    else 
+                    {
+                        Write-Output "..."
+                    }
+
                     Break
                 }
             }
@@ -89,7 +105,7 @@ function Write-OutputMessage (
         return
     }
 
-    Write-Output $MessageHeader
+    Write-Output $rawHeader
 }
 
 <#

--- a/PesterTests/GitHooksRunner_CommonFunctions.Tests.ps1
+++ b/PesterTests/GitHooksRunner_CommonFunctions.Tests.ps1
@@ -1,0 +1,300 @@
+<#
+.SYNOPSIS
+Tests of the functions in the GitHookSourceFilesToCopy\CommonGitHooks\PowerShellHooks\CommonFunctions.psm1 
+file.
+
+.NOTES
+Author:			Simon Elms
+Requires:		PowerShell 5
+                Pester v5
+Version:		1.0.0
+Date:			4 Jan 2024
+#>
+
+BeforeDiscovery {
+    # NOTE: The module under test has to be imported in a BeforeDiscovery block, not a 
+    # BeforeAll block.  If placed in a BeforeAll block the tests will fail with the following 
+    # message:
+    #   Discovery in ... failed with:
+    #   System.Management.Automation.RuntimeException: No modules named 'CommonFunctions' are 
+    #   currently loaded.
+
+    # Import is required, rather than dot source, since it doesn't seem possible to dot source 
+    # .psm1 files.  While the dot source doesn't produce an error, the functions in the file 
+    # are not available after dot sourcing.
+
+    # PowerShell allows multiple modules of the same name to be imported from different locations. 
+    # This would confuse Pester.  So, to be sure there are not multiple CommonFunctions modules 
+    # imported, remove all CommonFunctions modules and re-import only one.
+    Get-Module CommonFunctions | Remove-Module -Force
+
+    # Use $PSScriptRoot so this script will always import the CommonFunctions module in the 
+    # GitHooksSourceFilesToCopy folder adjacent to the folder containing this script, regardless 
+    # of the location that Pester is invoked from:
+    #
+    #                                     {parent folder}
+    #                                             |
+    #                   -----------------------------------------------------
+    #                   |                                                   |
+    #     {folder containing this script}                     GitHookSourceFilesToCopy folder
+    #                   |                                                   |
+    #                   |                                          CommonGitHooks folder
+    #                   |                                                   |
+    #                   |                                          PowerShellHooks folder
+    #                   |                                                   |
+    #               This script ----------> imports ------------>  module file under test
+    Import-Module (Join-Path $PSScriptRoot '..\GitHookSourceFilesToCopy\CommonGitHooks\PowerShellHooks\CommonFunctions.psm1' -Resolve) -Force
+}
+
+InModuleScope CommonFunctions {
+
+    Describe 'Write-OutputMessage' {
+    
+        BeforeAll {  
+
+            # The real Write-Output doesn't return a value but this is a good way of seeing what 
+            # the message it writes is.
+            Mock Write-Output { return $InputObject }
+        }
+
+        Context 'no arguments supplied' {
+
+            It 'writes empty string' {
+                $textWritten = Write-OutputMessage 
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be ''
+            } 
+        }
+
+        Context 'no message supplied' {
+
+            It 'writes supplied message header' {
+                $messageHeader = 'This is the header'
+
+                $textWritten = Write-OutputMessage -MessageHeader $messageHeader
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be $messageHeader
+            }  
+
+            It 'writes cached message header when no message header supplied' {
+                $messageHeader = 'Cached header'
+                $script:_messageHeader = $messageHeader
+
+                $textWritten = Write-OutputMessage
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be $messageHeader
+            } 
+
+            It 'writes supplied message header when different header cached' {
+                $script:_messageHeader = 'Cached header'
+                $messageHeader = 'This is the header'
+
+                $textWritten = Write-OutputMessage -MessageHeader $messageHeader
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be $messageHeader
+            }
+        }
+
+        Context 'message supplied is string' {
+
+            It 'writes message only when no message header supplied or cached' {
+                $message = 'This is the message'
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $message
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be $message
+            } 
+
+            It 'writes "supplied header: message" when message header supplied' {
+                $message = 'This is the message'
+                $messageHeader = 'Header'
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $message -MessageHeader $messageHeader
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be "$($messageHeader): $message"
+            }  
+
+            It 'writes "cached header: message" when message header cached' {
+                $message = 'This is the message'
+                $messageHeader = 'Cached Header'
+                $script:_messageHeader = $messageHeader
+
+                $textWritten = Write-OutputMessage -Message $message 
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be "$($messageHeader): $message"
+            } 
+
+            It 'writes "supplied header: message" when message header suplied and different header cached' {
+                $message = 'This is the message'
+                $messageHeader = 'Supplied Header'
+                $script:_messageHeader = 'Cached Header'
+
+                $textWritten = Write-OutputMessage -Message $message -MessageHeader $messageHeader
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be "$($messageHeader): $message"
+            }  
+
+            It 'writes message as per normal when -WriteFirstLineOnly switch set' {
+                $message = 'This is the message'
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $message -WriteFirstLineOnly
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be $message
+            } 
+        }
+
+        Context 'message supplied is array with one string element' {
+
+            BeforeEach {
+                $message = 'This is the message'
+                $messageArray = @( $message )
+            }
+
+            It 'writes message only when no message header supplied or cached' {
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $messageArray
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be $message
+            } 
+
+            It 'writes "supplied header: message" when message header supplied' {
+                $messageHeader = 'Header'
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $messageArray -MessageHeader $messageHeader
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be "$($messageHeader): $message"
+            }  
+
+            It 'writes "cached header: message" when message header cached' {
+                $messageHeader = 'Cached Header'
+                $script:_messageHeader = $messageHeader
+
+                $textWritten = Write-OutputMessage -Message $messageArray 
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be "$($messageHeader): $message"
+            } 
+
+            It 'writes "supplied header: message" when message header suplied and different header cached' {
+                $messageHeader = 'Supplied Header'
+                $script:_messageHeader = 'Cached Header'
+
+                $textWritten = Write-OutputMessage -Message $messageArray -MessageHeader $messageHeader
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be "$($messageHeader): $message"
+            } 
+
+            It 'writes single message when -WriteFirstLineOnly switch set' {
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $messageArray -WriteFirstLineOnly
+
+                Should -Invoke Write-Output -Times 1 -Exactly
+                $textWritten | Should -Be $message
+            } 
+        }
+
+        Context 'message supplied is array with multiple string elements, and -WriteFirstLineOnly switch not set' {
+
+            BeforeEach {
+                $message1 = 'Message 1'
+                $message2 = 'Message 2'
+                $message3 = 'Message 3'
+                $messageArray = @( $message1, $message2, $message3 )
+                $messageCount = $messageArray.Count
+            }
+
+            It 'writes separate message for each element in the message array' {
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $messageArray
+
+                Should -Invoke Write-Output -Times $messageCount -Exactly
+                Should -ActualValue $textWritten -BeOfType [System.Array]
+                $textWritten.Count | Should -Be $messageCount
+                for($i = 0; $i -lt $messageCount; $i++)
+                {
+                    $textWritten[$i] | Should -Be $messageArray[$i]
+                }
+            } 
+
+            It 'prepends message header to each message in the message array when message header supplied' {
+                $messageHeader = 'Header'
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $messageArray -MessageHeader $messageHeader
+
+                Should -Invoke Write-Output -Times $messageCount -Exactly
+                Should -ActualValue $textWritten -BeOfType [System.Array]
+                $textWritten.Count | Should -Be $messageCount
+                for($i = 0; $i -lt $messageCount; $i++)
+                {
+                    $textWritten[$i] | Should -Be "${messageHeader}: $($messageArray[$i])"
+                }
+            } 
+        }
+
+        Context 'message supplied is array with multiple string elements, and -WriteFirstLineOnly switch is set' {
+
+            BeforeEach {
+                $message1 = 'Message 1'
+                $message2 = 'Message 2'
+                $message3 = 'Message 3'
+                $messageArray = @( $message1, $message2, $message3 )
+                $messageCount = $messageArray.Count
+            }
+
+            It 'writes only two messages when there are more than two elements in the message array' {
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $messageArray -WriteFirstLineOnly
+
+                Should -Invoke Write-Output -Times 2 -Exactly
+                Should -ActualValue $textWritten -BeOfType [System.Array]
+                $textWritten.Count | Should -Be 2
+            }
+
+            It 'first message written is first element in the message array' {
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $messageArray -WriteFirstLineOnly
+
+                $textWritten[0] | Should -Be $message1
+            }
+
+            It 'second message written is "..." when no message header supplied or cached' {
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $messageArray -WriteFirstLineOnly
+
+                $textWritten[1] | Should -Be '...'
+            } 
+
+            It 'second message written is "header: ..." when message header supplied' {
+                $messageHeader = 'Header'
+                $script:_messageHeader = ''
+
+                $textWritten = Write-OutputMessage -Message $messageArray -MessageHeader $messageHeader -WriteFirstLineOnly
+
+                $textWritten[1] | Should -Be "${messageHeader}: ..."
+            } 
+        }
+    }
+}

--- a/PesterTests/GitHooksRunner_prepare-commit-msg.Tests.ps1
+++ b/PesterTests/GitHooksRunner_prepare-commit-msg.Tests.ps1
@@ -1,0 +1,804 @@
+<#
+.SYNOPSIS
+Tests of the functions in the GitHookSourceFilesToCopy\CommonGitHooks\PowerShellHooks\prepare-commit-msg.psm1 
+file.
+
+.NOTES
+Author:			Simon Elms
+Requires:		PowerShell 5
+                Pester v5
+Version:		1.0.0
+Date:			4 Jan 2024
+#>
+
+BeforeDiscovery {
+    # NOTE: The module under test has to be imported in a BeforeDiscovery block, not a 
+    # BeforeAll block.  If placed in a BeforeAll block the tests will fail with the following 
+    # message:
+    #   Discovery in ... failed with:
+    #   System.Management.Automation.RuntimeException: No modules named 'prepare-commit-msg' are 
+    #   currently loaded.
+
+    # Import is required, rather than dot source, since it doesn't seem possible to dot source 
+    # .psm1 files.  While the dot source doesn't produce an error, the functions in the file 
+    # are not available after dot sourcing.
+
+    # PowerShell allows multiple modules of the same name to be imported from different locations. 
+    # This would confuse Pester.  So, to be sure there are not multiple prepare-commit-msg modules 
+    # imported, remove all prepare-commit-msg modules and re-import only one.
+    Get-Module prepare-commit-msg | Remove-Module -Force
+
+    # Use $PSScriptRoot so this script will always import the prepare-commit-msg module in the 
+    # GitHooksSourceFilesToCopy folder adjacent to the folder containing this script, regardless 
+    # of the location that Pester is invoked from:
+    #
+    #                                     {parent folder}
+    #                                             |
+    #                   -----------------------------------------------------
+    #                   |                                                   |
+    #     {folder containing this script}                     GitHookSourceFilesToCopy folder
+    #                   |                                                   |
+    #                   |                                          CommonGitHooks folder
+    #                   |                                                   |
+    #                   |                                          PowerShellHooks folder
+    #                   |                                                   |
+    #               This script ----------> imports ------------>  module file under test
+    Import-Module (Join-Path $PSScriptRoot '..\GitHookSourceFilesToCopy\CommonGitHooks\PowerShellHooks\prepare-commit-msg.psm1' -Resolve) -Force
+}
+
+InModuleScope prepare-commit-msg {
+
+    BeforeAll {
+        Mock Exit-WithSuccess 
+        Mock Write-OutputMessage { return $Message }
+    }
+
+    Describe 'Exit-WithMessage' {
+
+        It 'calls Exit-WithSuccess' {
+            Exit-WithMessage 'test message'
+
+            Should -Invoke Exit-WithSuccess -Times 1 -Exactly
+        } 
+
+        It 'writes supplied message' {
+            $message = 'Test message'
+
+            $messageWritten = Exit-WithMessage $message
+
+            $messageWritten | Should -Be $message
+        }
+
+        It 'writes hard-coded message if no message supplied' {
+            $message = 'Commit message will not be modified.'
+
+            $messageWritten = Exit-WithMessage
+
+            $messageWritten | Should -Be $message
+        } 
+    }
+
+    Describe 'Remove-KnownPrefixFromBranchName' {
+
+        BeforeEach {
+            $script:_branchPrefixesToIgnore = @(
+                'feature',
+                'bug'
+            )
+        }
+
+        It 'returns branch name unchanged when it does not contain a known prefix' {
+            $rawBranchName = 'test-branch-name'
+
+            $modifiedBranchName = Remove-KnownPrefixFromBranchName -BranchName $rawBranchName
+
+            $modifiedBranchName | Should -Be $rawBranchName
+        }
+
+        It 'returns branch name unchanged when known prefix is not at start of branch name' {
+            $rawBranchName = 'otherText-bug/test-branch-name'
+
+            $modifiedBranchName = Remove-KnownPrefixFromBranchName -BranchName $rawBranchName
+
+            $modifiedBranchName | Should -Be $rawBranchName
+        }
+
+        It 'returns branch name unchanged when known prefix is not followed by a separator character' {
+            $rawBranchName = 'bugtest-branch-name'
+
+            $modifiedBranchName = Remove-KnownPrefixFromBranchName -BranchName $rawBranchName
+
+            $modifiedBranchName | Should -Be $rawBranchName
+        }
+
+        It 'returns branch name unchanged when separator character used is not a known separator character' {
+            $rawBranchName = 'bug~test-branch-name'
+
+            $modifiedBranchName = Remove-KnownPrefixFromBranchName -BranchName $rawBranchName
+
+            $modifiedBranchName | Should -Be $rawBranchName
+        }
+
+        It 'returns branch name unchanged when separator character is not followed by any further characters' {
+            $rawBranchName = 'bug/'
+
+            $modifiedBranchName = Remove-KnownPrefixFromBranchName -BranchName $rawBranchName
+
+            $modifiedBranchName | Should -Be $rawBranchName
+        }
+
+        It 'returns branch name unchanged when known prefix name is not followed by any further characters' {
+            $rawBranchName = 'bug'
+
+            $modifiedBranchName = Remove-KnownPrefixFromBranchName -BranchName $rawBranchName
+
+            $modifiedBranchName | Should -Be $rawBranchName
+        }
+
+        It 'returns branch name with prefix and separator stripped out when branch name starts with known prefix + known separator, followed by further text' {
+            $rawBranchName = 'bug/test-branch-name'
+            $expectedResult = 'test-branch-name'
+
+            $modifiedBranchName = Remove-KnownPrefixFromBranchName -BranchName $rawBranchName
+
+            $modifiedBranchName | Should -Be $expectedResult
+        }
+    }
+
+    Describe 'Get-CommitMessagePrefix' {
+
+        BeforeEach {
+            $script:_branchPrefixesToIgnore = @(
+                'feature',
+                'bug'
+            )
+        }
+
+        Context 'branch name has no branch prefix, Jira-style issue number or numeric issue number' {
+
+            It 'returns branch name unchanged' {
+                $rawBranchName = 'test-branch-name'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $rawBranchName
+            }
+
+        }
+
+        Context 'branch name has known branch prefix but no Jira-style issue number or numeric issue number' {
+
+            It 'returns branch name unchanged when known prefix is not at start of branch name' {
+                $rawBranchName = 'otherText-bug/test-branch-name'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $rawBranchName
+            }
+    
+            It 'returns branch name unchanged when known prefix is not followed by a separator character' {
+                $rawBranchName = 'bugtest-branch-name'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $rawBranchName
+            }
+    
+            It 'returns branch name unchanged when separator character used is not a known separator character' {
+                $rawBranchName = 'bug~test-branch-name'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $rawBranchName
+            }
+    
+            It 'returns branch name unchanged when separator character is not followed by any further characters' {
+                $rawBranchName = 'bug/'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $rawBranchName
+            }
+    
+            It 'returns branch name unchanged when known prefix name is not followed by any further characters' {
+                $rawBranchName = 'bug'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $rawBranchName
+            }
+    
+            It 'returns branch name with prefix and separator stripped out when branch name starts with known prefix + known separator, followed by further text' {
+                $rawBranchName = 'bug/test-branch-name'
+                $expectedResult = 'test-branch-name'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+        }
+
+        Context 'branch name has Jira-style issue number but no known branch prefix' {
+
+            It 'returns hyphen-separated Jira ticket number unchanged when the branch name is the ticket number with no further text' {
+                $rawBranchName = 'ACME-123'
+                $expectedResult = $rawBranchName
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'converts Jira project code to uppercase' {
+                $rawBranchName = 'acme-123'
+                $expectedResult = 'ACME-123'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -BeExactly $expectedResult
+            }
+
+            It 'adds hyphen between Jira project code and ticket number when no hyphen is present in branch name' {
+                $rawBranchName = 'acme123'
+                $expectedResult = 'ACME-123'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -BeExactly $expectedResult
+            }
+
+            It 'returns hyphen-separated Jira ticket number only, when the branch name is the ticket number immediately followed by further text' {
+                $rawBranchName = 'acme-123further-text'
+                $expectedResult = 'ACME-123'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns hyphen-separated Jira ticket number only, when the branch name is the ticket number followed by a hyphen and further text' {
+                $rawBranchName = 'acme-123-further-text'
+                $expectedResult = 'ACME-123'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns hyphen-separated Jira ticket number only, when the branch name is the ticket number followed by an underscore and further text' {
+                $rawBranchName = 'acme-123_further-text'
+                $expectedResult = 'ACME-123'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns hyphen-separated Jira ticket number only, when the branch name is the ticket number followed by a forward slash and further text' {
+                $rawBranchName = 'acme-123/further-text'
+                $expectedResult = 'ACME-123'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns both Jira ticket numbers, separated by a hyphen, when two Jira ticket numbers are present without any separator between them' {
+                $rawBranchName = 'acme-123smiths987further-text'
+                $expectedResult = 'ACME-123-SMITHS-987'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns both Jira ticket numbers, separated by a hyphen, when two Jira ticket numbers are present, separated by a hyphen' {
+                $rawBranchName = 'acme-123-smiths987further-text'
+                $expectedResult = 'ACME-123-SMITHS-987'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns both Jira ticket numbers, separated by a hyphen, when two Jira ticket numbers are present, separated by an underscore' {
+                $rawBranchName = 'acme-123_smiths987further-text'
+                $expectedResult = 'ACME-123-SMITHS-987'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns only the first two Jira ticket numbers, separated by a hyphen, when three or more Jira ticket numbers are present' {
+                $rawBranchName = 'acme-123smiths987acme-345further-text'
+                $expectedResult = 'ACME-123-SMITHS-987'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+        }
+
+        Context 'branch name has numeric issue number but no known branch prefix' {
+
+            It 'returns ticket number unchanged when the branch name is the ticket number with no further text' {
+                $rawBranchName = '123456'
+                $expectedResult = $rawBranchName
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns ticket number only, when the branch name is the ticket number immediately followed by further text' {
+                $rawBranchName = '123456further-text'
+                $expectedResult = '123456'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns ticket number only, when the branch name is the ticket number followed by a hyphen and further text' {
+                $rawBranchName = '123456-further-text'
+                $expectedResult = '123456'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns ticket number only, when the branch name is the ticket number followed by an underscore and further text' {
+                $rawBranchName = '123456_further-text'
+                $expectedResult = '123456'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns ticket number only, when the branch name is the ticket number followed by a forward slash and further text' {
+                $rawBranchName = '123456/further-text'
+                $expectedResult = '123456'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns both ticket numbers, separated by a hyphen, when two numeric ticket numbers are present, separated by a hyphen' {
+                $rawBranchName = '123456-987654further-text'
+                $expectedResult = '123456-987654'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns both ticket numbers, separated by a hyphen, when two numeric ticket numbers are present, separated by an underscore' {
+                $rawBranchName = '123456_987654further-text'
+                $expectedResult = '123456-987654'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns only the first two ticket numbers, separated by a hyphen, when three or more numeric ticket numbers are present' {
+                $rawBranchName = '123456-987654-345678further-text'
+                $expectedResult = '123456-987654'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+        }
+
+        Context 'branch name has known branch prefix and Jira-style issue number' {
+
+            It 'returns hyphen-separated Jira ticket number when the branch name has a known branch prefix and the Jira ticket number with no further text' {
+                $rawBranchName = 'bug/acme-123'
+                $expectedResult = 'ACME-123'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns hyphen-separated Jira ticket number when the branch name has a known branch prefix followed by a hyphen separator and the Jira ticket number' {
+                $rawBranchName = 'bug-acme123'
+                $expectedResult = 'ACME-123'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -BeExactly $expectedResult
+            }
+
+            It 'returns hyphen-separated Jira ticket number only, when the branch name has a known branch prefix, the ticket number and further text' {
+                $rawBranchName = 'bug.acme-123further-text'
+                $expectedResult = 'ACME-123'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns hyphen-separated Jira ticket number only, when the branch name has a known branch prefix, then the ticket number followed by a forward slash and further text' {
+                $rawBranchName = 'bug/acme-123/further-text'
+                $expectedResult = 'ACME-123'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+
+            It 'returns both Jira ticket numbers, when the branch name has a known branch prefix, two ticket numbers, then further text' {
+                $rawBranchName = 'bug/acme-123smiths987further-text'
+                $expectedResult = 'ACME-123-SMITHS-987'
+    
+                $messagePrefix = Get-CommitMessagePrefix -BranchName $rawBranchName
+    
+                $messagePrefix | Should -Be $expectedResult
+            }
+        }
+    }
+
+    Describe 'Exit-IfEditingExistingCommit' {
+
+        BeforeAll {
+            Mock Write-OutputMessage { return $Message }
+            Mock Exit-WithSuccess
+        }
+
+        Context 'fixup commit' {
+            
+            BeforeEach {
+                $existingCommitMessageFirstLine = 'fixup! Commit message'
+                $commitMessagePrefix = 'ACME-123'
+            }
+
+            It 'calls Exit-WithSuccess' {
+
+                $messageWritten = Exit-IfEditingExistingCommit `
+                    -ExistingCommitMessageFirstLine $existingCommitMessageFirstLine `
+                    -CommitMessagePrefix $commitMessagePrefix
+
+                Should -Invoke Exit-WithSuccess -Times 1 -Exactly
+            } 
+
+            It 'writes "not modified" message' {
+                $message = 'Fixup commit message will not be modified.'
+
+                $messageWritten = Exit-IfEditingExistingCommit `
+                    -ExistingCommitMessageFirstLine $existingCommitMessageFirstLine `
+                    -CommitMessagePrefix $commitMessagePrefix
+
+                $messageWritten | Should -Be $message
+            }
+        }
+
+        Context 'squash commit' {
+            
+            BeforeEach {
+                $existingCommitMessageFirstLine = 'squash! Commit message'
+                $commitMessagePrefix = 'ACME-123'
+            }
+
+            It 'calls Exit-WithSuccess' {
+
+                $messageWritten = Exit-IfEditingExistingCommit `
+                    -ExistingCommitMessageFirstLine $existingCommitMessageFirstLine `
+                    -CommitMessagePrefix $commitMessagePrefix
+
+                Should -Invoke Exit-WithSuccess -Times 1 -Exactly
+            } 
+
+            It 'writes "not modified" message' {
+                $message = 'Squash commit message will not be modified.'
+
+                $messageWritten = Exit-IfEditingExistingCommit `
+                    -ExistingCommitMessageFirstLine $existingCommitMessageFirstLine `
+                    -CommitMessagePrefix $commitMessagePrefix
+
+                $messageWritten | Should -Be $message
+            }
+        }
+
+        Context 'commit message already has prefix' {
+            
+            BeforeEach {
+                $existingCommitMessageFirstLine = 'ACME-123: Commit message'
+                $commitMessagePrefix = 'ACME-123'
+            }
+
+            It 'calls Exit-WithSuccess' {
+
+                $messageWritten = Exit-IfEditingExistingCommit `
+                    -ExistingCommitMessageFirstLine $existingCommitMessageFirstLine `
+                    -CommitMessagePrefix $commitMessagePrefix
+
+                Should -Invoke Exit-WithSuccess -Times 1 -Exactly
+            } 
+
+            It 'writes "not modified" message' {
+                $message = 'Commit message already has a prefix; commit message will not be modified.'
+
+                $messageWritten = Exit-IfEditingExistingCommit `
+                    -ExistingCommitMessageFirstLine $existingCommitMessageFirstLine `
+                    -CommitMessagePrefix $commitMessagePrefix
+
+                $messageWritten | Should -Be $message
+            }
+        }
+
+        Context 'commit message has no prefix' {
+
+            BeforeEach {
+                $existingCommitMessageFirstLine = 'Commit message'
+                $commitMessagePrefix = 'ACME-123'
+            }
+
+            It 'does not call Exit-WithSuccess' {
+
+                $messageWritten = Exit-IfEditingExistingCommit `
+                    -ExistingCommitMessageFirstLine $existingCommitMessageFirstLine `
+                    -CommitMessagePrefix $commitMessagePrefix
+
+                Should -Invoke Exit-WithSuccess -Times 0 
+            } 
+
+            It 'does not write any message' {
+
+                $messageWritten = Exit-IfEditingExistingCommit `
+                    -ExistingCommitMessageFirstLine $existingCommitMessageFirstLine `
+                    -CommitMessagePrefix $commitMessagePrefix
+
+                $messageWritten | Should -Be $Null
+            }
+        }
+    }
+
+    Describe 'Start-GitHook' {
+
+        BeforeAll {      
+            $testMessagePrefix = 'message prefix'
+            $testBranchName = 'branch name'
+            $testOriginalCommitMessage = 'file content'
+
+            Mock Write-OutputMessage { return $Message }    
+            Mock Exit-WithMessage { throw $Message }
+            Mock Get-BranchName { return $testBranchName }
+            Mock Get-CommitMessagePrefix { return $testMessagePrefix }
+            Mock Test-Path { return $True }
+            Mock Get-Content { return $testOriginalCommitMessage }
+            Mock Set-IndentOnFileContent { return "  $testOriginalCommitMessage" }
+            Mock Exit-IfEditingExistingCommit
+            Mock Set-Content
+            Mock Exit-WithSuccess
+        }
+
+        BeforeEach {
+            $commitMessageFilePath = 'C:\messagefilepath'
+            $commitType = 'message'
+            $commitHash = 'a1b2c3d'
+            $script:_branchNamesToIgnore = @('master', 'main')
+        }
+
+        Context 'CommitMessageFilePath parameter not set' {
+
+            It 'exits with error message when -CommitMessageFilePath is $null' {
+                $commitMessageFilePath = $null
+                $expectedMessage = 'The path to the commit message temp file was not passed to the Start-GitHook function.*'
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw -ExpectedMessage $expectedMessage
+            }
+
+            It 'does not call Get-BranchName when -CommitMessageFilePath is $null' {
+                $commitMessageFilePath = $null
+                $expectedMessage = 'The path to the commit message temp file was not passed to the Start-GitHook function.*'
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw -ExpectedMessage $expectedMessage
+
+                Should -Invoke Get-BranchName -Times 0
+            }
+
+            It 'exits with error message when -CommitMessageFilePath is empty string' {
+                $commitMessageFilePath = ''
+                $expectedMessage = 'The path to the commit message temp file was not passed to the Start-GitHook function.*'
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw -ExpectedMessage $expectedMessage
+            }
+
+            It 'does not call Get-BranchName when -CommitMessageFilePath is empty string' {
+                $commitMessageFilePath = ''
+                $expectedMessage = 'The path to the commit message temp file was not passed to the Start-GitHook function.*'
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw -ExpectedMessage $expectedMessage
+
+                Should -Invoke Get-BranchName -Times 0
+            }
+
+            It 'exits with error message when -CommitMessageFilePath is white space' {
+                $commitMessageFilePath = '  '
+                $expectedMessage = 'The path to the commit message temp file was not passed to the Start-GitHook function.*'
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw -ExpectedMessage $expectedMessage
+            }
+
+            It 'does not call Get-BranchName when -CommitMessageFilePath is white space' {
+                $commitMessageFilePath = '  '
+                $expectedMessage = 'The path to the commit message temp file was not passed to the Start-GitHook function.*'
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw -ExpectedMessage $expectedMessage
+
+                Should -Invoke Get-BranchName -Times 0
+            }
+        }
+
+        Context 'CommitMessageFilePath parameter points to non-existent file' {
+
+            BeforeAll {
+                Mock Test-Path { return $False }
+            }
+
+            It 'exits with error message when no file found at -CommitMessageFilePath' {
+                $expectedMessage = "Could not find commit message temp file '$commitMessageFilePath'.*"
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw -ExpectedMessage $expectedMessage
+            }
+
+            It 'does not call Get-Content when no file found at -CommitMessageFilePath' {
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw
+
+                Should -Invoke Get-Content -Times 0
+            }
+        }
+
+        Context 'Git branch name is $null' {
+            # Occurs when the checked out commit is not the head of a branch.
+
+            BeforeAll {
+                Mock Get-BranchName { return $Null }
+                Mock Get-Content { return '' } 
+            }
+
+            It 'exits with error message when Git branch name is $null' {
+                $expectedMessage = 'Could not read git branch name.*'
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw -ExpectedMessage $expectedMessage
+            }
+
+            It 'does not call Get-CommitMessagePrefix when Git branch name is $null' {
+                Mock Get-CommitMessagePrefix { return '' }
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw
+
+                Should -Invoke Get-CommitMessagePrefix -Times 0
+            }
+        }
+
+        Context 'Git branch name is not $null' {
+
+            It 'calls Get-CommitMessagePrefix, passing in branch name' {
+                Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                    -CommitType $commitType -CommitHash $commitHash
+
+                Should -Invoke Get-CommitMessagePrefix -Times 1 -Exactly -ParameterFilter { $BranchName -eq $testBranchName }
+            }
+
+            It 'exits with error message when Git branch name is a reserved branch name' {
+                $script:_branchNamesToIgnore += $testBranchName
+                $expectedMessage = "Committing to reserved branch $testBranchName.*"
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw -ExpectedMessage $expectedMessage
+            }
+
+            It 'does not call Get-Content when Git branch name is a reserved branch name' {
+                $script:_branchNamesToIgnore += $testBranchName
+
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Throw
+
+                Should -Invoke Get-Content -Times 0
+            }
+
+            It 'calls Get-Content when Git branch name is not a reserved branch name' {
+                { Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                        -CommitType $commitType -CommitHash $commitHash } | 
+                Should -Not -Throw
+
+                Should -Invoke Get-Content -Times 1 -Exactly
+            }
+        }
+
+        Context 'single-line commit message' {
+
+            It 'calls Exit-IfEditingExistingCommit' {
+                Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                    -CommitType $commitType -CommitHash $commitHash
+
+                Should -Invoke Exit-IfEditingExistingCommit -Times 1 -Exactly
+            }
+
+            It 'prepends message prefix to commit message' {
+                $newCommitMessage = "$($testMessagePrefix): $testOriginalCommitMessage"
+
+                Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                    -CommitType $commitType -CommitHash $commitHash
+
+                Should -Invoke Set-Content -Times 1 -Exactly `
+                    -ParameterFilter { $Path -eq $commitMessageFilePath -and $Value -eq $newCommitMessage }
+            }
+
+            It 'exits with exit code 0 (success)' {
+                Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                    -CommitType $commitType -CommitHash $commitHash
+
+                Should -Invoke Exit-WithSuccess -Times 1 -Exactly
+            }
+        }
+
+        Context 'multi-line commit message' {
+
+            BeforeEach {
+                
+                $testOriginalCommitMessage = @(
+                                        'commit message line 1'
+                                        'commit message line 2'
+                                    )
+
+                Mock Get-Content { return $testOriginalCommitMessage }
+            }
+
+            It 'calls Exit-IfEditingExistingCommit' {
+                Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                    -CommitType $commitType -CommitHash $commitHash
+
+                Should -Invoke Exit-IfEditingExistingCommit -Times 1 -Exactly
+            }
+
+            It 'prepends message prefix to first line of commit message, while leaving subsequent lines unchanged' {
+                $newCommitMessage = $testOriginalCommitMessage.Clone()
+                $newCommitMessage[0] = "$($testMessagePrefix): $($newCommitMessage[0])"
+
+                Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                    -CommitType $commitType -CommitHash $commitHash
+
+                Should -Invoke Set-Content -Times 1 -Exactly `
+                    -ParameterFilter { $Path -eq $commitMessageFilePath `
+                                -and $Null -eq (Compare-Object $Value $newCommitMessage) }
+            }
+
+            It 'exits with exit code 0 (success)' {
+                Start-GitHook -CommitMessageFilePath $commitMessageFilePath `
+                    -CommitType $commitType -CommitHash $commitHash
+
+                Should -Invoke Exit-WithSuccess -Times 1 -Exactly
+            }
+        }
+    }
+}

--- a/PesterTests/InvokeTests.txt
+++ b/PesterTests/InvokeTests.txt
@@ -20,6 +20,8 @@ Invoke-Pester "${testFolder}\GitHooksInstaller_GitHookFileFunctions.Tests.ps1" -
 
 Invoke-Pester "${testFolder}\GitHooksRunner_CommonFunctions.Tests.ps1" -Output Detailed
 
+Invoke-Pester "${testFolder}\GitHooksRunner_prepare-commit-msg.Tests.ps1" -Output Detailed
+
 -----------------------------------------------------
 # Run specified Describe block in specified test file
 -----------------------------------------------------

--- a/PesterTests/InvokeTests.txt
+++ b/PesterTests/InvokeTests.txt
@@ -1,0 +1,43 @@
+For Pester v5
+=============
+
+----------------------------------------------------------------------
+NOTE: The tests must be run under an Administrator PowerShell console.
+----------------------------------------------------------------------
+
+$testFolder = 'C:\...\PowerShell\Modules\GitHooks\PesterTests\'
+
+---------------
+# Run all tests
+---------------
+Invoke-Pester $testFolder -Output Detailed
+
+--------------------------
+# Run specified test files
+--------------------------
+Invoke-Pester "${testFolder}GitHooksInstaller_FileCopyFunctions.Tests.ps1" -Output Detailed
+
+Invoke-Pester "${testFolder}GitHooksInstaller_GitHookFileFunctions.Tests.ps1" -Output Detailed
+
+Invoke-Pester "${testFolder}GitHooksInstaller_VersionNumberFunctions.Tests.ps1" -Output Detailed
+
+Invoke-Pester "${testFolder}GitHooksInstalller_HelperFunctions.Tests.ps1" -Output Detailed
+
+-----------------------------------------------------
+# Run specified Describe block in specified test file
+-----------------------------------------------------
+# -FullNameFilter can only take the name of a Describe block, not a Context or It block
+Invoke-Pester "${testFolder}GitHooksInstaller_FileCopyFunctions.Tests.ps1" -FullNameFilter 'Set-TargetFileFromSourceDirectory' -Output Detailed
+
+# or:
+$config = New-PesterConfiguration
+$config.Run.Path = "${testFolder}GitHooksInstaller_FileCopyFunctions.Tests.ps1"
+$config.Filter.FullName = 'Set-TargetFileFromSourceDirectory'
+Invoke-Pester -Configuration $config
+
+---------------------------------------------
+# Run specified Context or It blocks via Tags
+---------------------------------------------
+# EG in test file:
+#	Context 'source file does not exist' -Tag 'RunThis' { ... }
+Invoke-Pester "${testFolder}GitHooksInstaller_FileCopyFunctions.Tests.ps1" -Tag 'RunThis', 'RunThat' -Output Detailed

--- a/PesterTests/InvokeTests.txt
+++ b/PesterTests/InvokeTests.txt
@@ -18,6 +18,8 @@ Invoke-Pester "${testFolder}\GitHooksInstaller_FileCopyFunctions.Tests.ps1" -Out
 
 Invoke-Pester "${testFolder}\GitHooksInstaller_GitHookFileFunctions.Tests.ps1" -Output Detailed
 
+Invoke-Pester "${testFolder}\GitHooksRunner_CommonFunctions.Tests.ps1" -Output Detailed
+
 -----------------------------------------------------
 # Run specified Describe block in specified test file
 -----------------------------------------------------

--- a/README_prepare-commit-msg.md
+++ b/README_prepare-commit-msg.md
@@ -2,61 +2,84 @@
 
 Modifies Git commit messages to prepend the branch name to the start of the commit message.
 
-For example, if you create a commit message *"My commit"* on branch *"acme-319"* then the message actually committed to Git will be *"ACME-319: My commit"*.
+For example, if you create a commit message `My commit` on branch `acme-319` then the message actually committed to Git will be `ACME-319: My commit`.
 
 ## Purpose
-To keep a repository tidy we want to delete short-lived branches, such as feature branches, once they are merged back into master.  However, we still want to be able to identify all the commits relating to a particular feature or issue after the branch they were made on has been deleted.  Automatically prepending the branch name to each commit message, at the time the commit is made, allows us to still link the commit to the feature after the branch has been deleted.
+
+To keep a repository tidy we want to delete short-lived branches, such as feature branches, once they are merged back into a long-lived branch like `main`. However, we still want to be able to identify all the commits relating to a particular feature or issue after the branch they were made on has been deleted. Automatically prepending the branch name to each commit message, at the time the commit is made, allows us to still link the commit to the feature after the branch has been deleted.
 
 ## Branches to ignore
-We only want to prepend the branch name to commit messages for short-lived branches, where the branch will be deleted after being merged back into master.  We want to ignore permanent branches, such as master or develop, so that commit messages for those branches don't include branch names.  
 
-The list of branch names to ignore is assigned to variable *$_branchNamesToIgnore* at the head of script *prepare-commit-msg.psm1*.  You may edit this list.
+We only want to prepend the branch name to commit messages for short-lived branches, where the branch will be deleted after being merged back into a long-lived branch like `main`. We want to ignore permanent branches, such as `main`, `master` or `develop`, so that commit messages for those branches don't include branch names.
+
+The list of long-lived branch names to ignore is assigned to variable `$_branchNamesToIgnore`, at the head of script _prepare-commit-msg.psm1_. You may edit this list.
+
+## Branch names which contain numeric issue numbers
+
+Some issue tracking systems, such as GitHub issues or Azure Boards, use numeric issue numbers. If a branch name starts with a number then the number is assumed to be an issue number. Only the number will be added to the commit message and the rest of the branch name will be ignored. For example, if the branch name is `134985_PartsReport` then the text prepended to the commit message will be `134985: `.
+
+The following branch names would be recognized as having numeric issue numbers:
+
+- `134985`
+- `134985partsreport`
+- `134985_partsreport`
+- `134985-partsreport`
+
+These would all result in `134985: ` being prepended to the commit message.
+
+The following branch names would **_not_** be recognized as having numeric issue numbers:
+
+- `acme_134985_partsreport` (branch name does not start with a number)
+- `partsreport_134985` (issue number at the end of the branch name, not the start)
+
+These would result in the full branch name being prepended to the commit message.
 
 ## Branch names which contain Jira issue numbers
-For branch names based on Jira issues (or any similar issue tracking system) only the Jira issue number will be added to the commit message.  For example, if the branch name is *"acme319_PartsReport"* then the text prepended to the commit message will be *"ACME-319: "*.  
 
-Issue numbers are recognized as text followed by a number at the start of the branch name, with an optional hyphen, "-", in between.  Everything after the number will be ignored.
+For branch names based on Jira issues (or any issue tracking system that uses a similar issue numbering scheme) only the Jira issue number will be added to the commit message. For example, if the branch name is `acme319_PartsReport` then the text prepended to the commit message will be `ACME-319: `.
+
+Jira-style issue numbers are recognized as text followed by a number at the start of the branch name, with an optional hyphen, `-`, in between. Everything after the number will be ignored.
 
 The following branch names would be recognized as having Jira issue numbers:
 
-* *"acme319"*
-* *"acme-319"*
-* *"acme319partsreport"*
-* *"acme319_partsreport"*
-* *"acme-319partsreport"*
-* *"acme-319_partsreport"*
+- `acme319`
+- `acme-319`
+- `acme319partsreport`
+- `acme319_partsreport`
+- `acme-319partsreport`
+- `acme-319_partsreport`
 
-These would all result in *"ACME-319: "* being prepended to the commit message.
+These would all result in `ACME-319: ` being prepended to the commit message.
 
-The following branch names would ***not*** be recognized as having Jira issue numbers:
+The following branch names would **_not_** be recognized as having Jira issue numbers:
 
-* *"319partsreport"*		(starts with a number, not text)
-* *"319-partsreport"*		(starts with a number, not text)
-* *"acme-partsreport"*		(no number follows the text at the start of the branch name)
-* *"partsreport_acme319"*	(Jira issue number at the end of the branch name, not the start)
-* *"acme_319"*				(text and number are separated by an underscore, not a hyphen)
+- `acme-partsreport` (no number follows the text at the start of the branch name)
+- `partsreport_acme319` (Jira issue number at the end of the branch name, not the start)
+- `acme_319` (text and number are separated by an underscore, not a hyphen)
 
 These would all result in the full branch name being prepended to the commit message.
 
 ## Branch names which contain known prefixes
-Some teams identify feature branches with a prefix, similar to *"feature/acme-319"*.  Known prefixes followed by a separator character will be stripped from the start of the branch name before it is prepended to the commit message.
 
-The list of known prefixes to remove is assigned to variable *$_branchPrefixesToIgnore* at the head of script *prepare-commit-msg.psm1*.  You may edit this list to add your own prefixes.
+Some teams identify feature branches with a prefix, similar to `feature/acme-319`. Known prefixes followed by a separator character will be stripped from the start of the branch name before it is prepended to the commit message.
+
+The list of known prefixes to remove is assigned to variable `$_branchPrefixesToIgnore` at the head of script _prepare-commit-msg.psm1_. You may edit this list to add your own prefixes.
 
 Valid separator characters, between the prefix and the remainder of the branch name, are:
 
-* */ (forward slash)*
-* *. (dot)*
-* *- (hyphen)*
-* *_ (underscore)*
+- `/` (forward slash)
+- `.` (dot)
+- `-` (hyphen)
+- `\` (underscore)
 
-Known prefixes are removed from the branch name before the script searches for a Jira ticket number.  This means the script will still recognize Jira ticket numbers preceded by a known prefix.  For example, branch name *"feature/acme319_partsreport"* would result in just *"ACME-319: "* being prepended to the commit message.
+Known prefixes are removed from the branch name before the script searches for an issue number. This means the script will still recognize issue numbers preceded by a known prefix. For example, branch name `feature/acme319_partsreport` would result in just `ACME-319: ` being prepended to the commit message.
 
 ## The commit message will not be modified when
-1. The commit is on an ignored branch, such as master or develop.  The list of ignored branch names is assigned to variable *$_branchNamesToIgnore* at the head of script *prepare-commit-msg.psm1*;
 
-1. The commit message already has the branch name prepended (for example, if the user has manually included the branch name at the start of the message, of if the user is amending an existing commit which already has the branch name at the start of the message);
+1. The commit is on an ignored branch, such as `main`, `master` or `develop`. The list of ignored branch names is assigned to variable `$_branchNamesToIgnore` at the head of script _prepare-commit-msg.psm1_. You may edit this list to add your own branch names to ignore;
 
-1. The HEAD is a detached HEAD.  In other words, the checked out commit is not at the head of a branch.  In that case we can't read the branch name so cannot preprend it to the commit message;
+1. The commit message already has the branch name prepended (for example, if the user has manually included the branch name at the start of the message, or if the user is amending an existing commit which already has the branch name at the start of the message);
 
-1. Modifying existing commits via an interactive rebase.
+1. The `HEAD` is a detached `HEAD`. In other words, the checked out commit is not at the head of a branch. In that case we can't read the branch name so cannot preprend it to the commit message;
+
+1. Modifying existing commits via a rebase.


### PR DESCRIPTION
Changes to prepare-commit-msg.psm1 script:

Issue-001: Extract numeric issue numbers from branch names to use as commit message prefixes, in addition to the previous Jira-style issue numbers.

Issue-002: If a branch name contains parent issue number + child issue number, extract both to use as the commit message prefix.